### PR TITLE
feat: 피드 CARETE / READ 구현

### DIFF
--- a/src/core/dto/base-pagination.dto.ts
+++ b/src/core/dto/base-pagination.dto.ts
@@ -1,8 +1,8 @@
 import { Expose, Type } from 'class-transformer';
 import { BaseDto } from './base.dto';
-import { Max, Min } from 'class-validator';
+import { IsNumber, Max, Min } from 'class-validator';
 
-export class BasePaginationDto {
+export class BasePaginationDto<T> extends BaseDto<T> {
   @Type(() => Number)
   @Min(1)
   @Expose()

--- a/src/core/vo/paginate-response.vo.ts
+++ b/src/core/vo/paginate-response.vo.ts
@@ -3,5 +3,9 @@ import { BaseVo } from './base.vo';
 export class PaginateResponseVo<T> {
   items: T[];
   totalCount: number;
-  page: number;
+  pageInfo: {
+    page: number;
+    limit: number;
+    isLast: boolean;
+  };
 }

--- a/src/modules/feed/dto/feed-list.dto.ts
+++ b/src/modules/feed/dto/feed-list.dto.ts
@@ -3,7 +3,7 @@ import { Expose } from 'class-transformer';
 import { IsOptional } from 'class-validator';
 import { BasePaginationDto } from 'src/core';
 
-export class FeedListDto extends BasePaginationDto {
+export class FeedListDto extends BasePaginationDto<FeedListDto> {
   @ApiPropertyOptional()
   @IsOptional()
   @Expose()

--- a/src/modules/feed/feed.controller.ts
+++ b/src/modules/feed/feed.controller.ts
@@ -42,11 +42,11 @@ export class FeedController {
   @Get('/:username')
   @HttpCode(HttpStatus.OK)
   public async findAllByUser(
-    @UserInfo() user: User,
     @Param('username') username: string,
+    @Query() feedListDto: FeedListDto,
   ): Promise<BaseResponseVo<FeedFindOneVo[]>> {
     return new BaseResponseVo<FeedFindOneVo[]>(
-      await this.feedService.findAllByUser(username),
+      await this.feedService.findAllByUser(username, feedListDto),
     );
   }
 

--- a/src/modules/feed/feed.repository.ts
+++ b/src/modules/feed/feed.repository.ts
@@ -7,12 +7,15 @@ import { FEED_STATUS, YN } from 'src/common';
 import { FeedCreateDto, FeedListDto } from './dto';
 import { FeedImage } from '../feed-image/feed-image.entity';
 import { BaseResponseVo, PaginateResponseVo } from 'src/core';
+import { User } from '../user/user.entity';
 
 @Injectable()
 export class FeedRepository {
   constructor(
     @Inject(DB_CONST_REPOSITORY.FEED)
-    private readonly feedRepository: Repository<Feed>, // @Inject(DB_CONST_REPOSITORY.FEED_IMAGE) // private readonly feedImageRepository: Repository<FeedImage>,
+    private readonly feedRepository: Repository<Feed>,
+    @Inject(DB_CONST_REPOSITORY.USER)
+    private readonly userRepository: Repository<User>,
   ) {}
 
   // SELECTS
@@ -181,6 +184,13 @@ export class FeedRepository {
           }),
         );
       }
+      // TODO: user feed count 증가
+      let user = await this.userRepository.findOne({
+        where: { id: userId },
+      });
+
+      user.feedCount++;
+      user = await transaction.save(user);
       // TODO: description 에 tag 있는 경우 tag, mapper_feed_tag 테이블 생성
 
       return newFeed;

--- a/src/modules/feed/feed.repository.ts
+++ b/src/modules/feed/feed.repository.ts
@@ -24,10 +24,8 @@ export class FeedRepository {
   public async findAll(
     feedListDto?: FeedListDto,
   ): Promise<PaginateResponseVo<FeedFindOneVo>> {
-    console.log('feedListDto', feedListDto);
-    const page = feedListDto?.page || 1;
-    const limit = feedListDto?.limit || 10;
-
+    const page = feedListDto?.page;
+    const limit = feedListDto?.limit;
     const offset = (page - 1) * limit;
 
     const feeds = this.feedRepository
@@ -54,7 +52,8 @@ export class FeedRepository {
       .offset(offset)
       .limit(limit);
 
-    const items = await feeds.getMany();
+    const [items, totalCount] = await feeds.getManyAndCount();
+    const lasPage = Math.ceil(totalCount / limit);
 
     for (const item of items) {
       item.feedImages = await FeedImage.createQueryBuilder('feedImage')
@@ -64,8 +63,12 @@ export class FeedRepository {
 
     return {
       items: items,
-      totalCount: items.length,
-      page: 2,
+      totalCount: totalCount,
+      pageInfo: {
+        page,
+        limit,
+        isLast: page === lasPage ? true : false,
+      },
     };
   }
 
@@ -74,11 +77,17 @@ export class FeedRepository {
    * @param userId
    * @returns
    */
-  public async findAllByUser(userId: number): Promise<FeedFindOneVo[]> {
-    const feeds = await this.feedRepository
+  public async findAllByUser(
+    userId: number,
+    feedListDto?: FeedListDto,
+  ): Promise<PaginateResponseVo<FeedFindOneVo>> {
+    const page = feedListDto?.page;
+    const limit = feedListDto?.limit;
+    const offset = (page - 1) * limit;
+
+    const feeds = this.feedRepository
       .createQueryBuilder('feed')
       .leftJoinAndSelect('feed.user', 'user')
-      .leftJoinAndSelect('feed.feedImages', 'feedImages')
       .select([
         'feed.id',
         'feed.userId',
@@ -93,17 +102,32 @@ export class FeedRepository {
         'user.username',
         'user.nickname',
         'user.profileImage',
-        'feedImages.feedId',
-        'feedImages.image',
-        'feedImages.sortOrder',
       ])
       .where('feed.displayYn = :displayYn', { displayYn: YN.Y })
       .andWhere('feed.status = :status', { status: FEED_STATUS.ACTIVE })
       .andWhere('feed.userId = :userId', { userId: userId })
       .orderBy('feed.createdAt', 'DESC')
-      .getMany();
+      .offset(offset)
+      .limit(limit);
 
-    return feeds;
+    const [items, totalCount] = await feeds.getManyAndCount();
+    const lasPage = Math.ceil(totalCount / limit);
+
+    for (const item of items) {
+      item.feedImages = await FeedImage.createQueryBuilder('feedImage')
+        .where('feedImage.feedId = :feedId', { feedId: item.id })
+        .getMany();
+    }
+
+    return {
+      items: items,
+      totalCount: totalCount,
+      pageInfo: {
+        page,
+        limit,
+        isLast: page === lasPage ? true : false,
+      },
+    };
   }
 
   /**

--- a/src/modules/feed/feed.service.ts
+++ b/src/modules/feed/feed.service.ts
@@ -22,19 +22,22 @@ export class FeedService {
   // GET SERVICES
 
   public async findAll(
-    feedListDto: FeedListDto,
+    feedListDto?: FeedListDto,
   ): Promise<PaginateResponseVo<FeedFindOneVo>> {
     const feeds = await this.feedRepository.findAll(feedListDto);
     if (!feeds) throw new NotFoundException();
     return feeds;
   }
 
-  public async findAllByUser(username: string): Promise<FeedFindOneVo[]> {
+  public async findAllByUser(
+    username: string,
+    feedListDto?: FeedListDto,
+  ): Promise<PaginateResponseVo<FeedFindOneVo>> {
     const user = await this.userRepository.findUserByUsername(username);
     if (!user) throw new NotFoundException();
     console.log(user);
 
-    const feeds = await this.feedRepository.findAllByUser(user.id);
+    const feeds = await this.feedRepository.findAllByUser(user.id, feedListDto);
     if (!feeds) throw new NotFoundException();
     return feeds;
   }


### PR DESCRIPTION
## 🐳 개요
피드 생성 및 목록 API 구현

## 🐳 작업사항
### 피드 목록
#### 전체 피드 목록
- 전체 목록 출력시 FEED_IMAGE 테이블을 leftJoin 걸어서 페이지네이션 처리 할 경우
  join 걸린 테이블의 배열 갯수 까지 영향을 받음 
 (예를들면, 피드 목록 limit 을 10으로 정할경우 join 걸린 피드 이미지 배열 또한 10개로 제한걸려버림)
- 이를 해결로하기 위해  우선 페이지 네이션 처리된 목록에 추가로 for문을 돌려서 FEED_IMAGE 배열을 바인딩하는 방법을 적용해봄
- 페이지 네이션에 관한 정보를 pageInfo 객체로 반환
  -  isLast (마지막 페이지) 여부를 `boolean` 값으로 반환
```ts
/**
   * 전체 피드 목록
   * @returns
   */
  public async findAll(
    feedListDto?: FeedListDto,
  ): Promise<PaginateResponseVo<FeedFindOneVo>> {
    const page = feedListDto?.page;
    const limit = feedListDto?.limit;
    const offset = (page - 1) * limit;

    const feeds = this.feedRepository
      .createQueryBuilder('feed')
      .leftJoinAndSelect('feed.user', 'user')
      .select([
        'feed.id',
        'feed.userId',
        'feed.description',
        'feed.status',
        'feed.likeCount',
        'feed.commentCount',
        'feed.showLikeCountYn',
        'feed.createdAt',
        'feed.updatedAt',
        'user.id',
        'user.username',
        'user.nickname',
        'user.profileImage',
      ])
      .where('feed.displayYn = :displayYn', { displayYn: YN.Y })
      .andWhere('feed.status = :status', { status: FEED_STATUS.ACTIVE })
      .orderBy('feed.createdAt', 'DESC')
      .offset(offset)
      .limit(limit);

    const [items, totalCount] = await feeds.getManyAndCount();
    const lasPage = Math.ceil(totalCount / limit);

    for (const item of items) {
      item.feedImages = await FeedImage.createQueryBuilder('feedImage')
        .where('feedImage.feedId = :feedId', { feedId: item.id })
        .getMany();
    }

    return {
      items: items,
      totalCount: totalCount,
      pageInfo: {
        page,
        limit,
        isLast: page === lasPage ? true : false,
      },
    };
  }
```
#### 유저별 피드 목록 (마이페이지)
- 전체 피드 목록과 로직은 비슷하며, userId를 이용하여 조건 적용
```ts
  /**
   * 유저별 피드 목록
   * @param userId
   * @returns
   */
  public async findAllByUser(
    userId: number,
    feedListDto?: FeedListDto,
  ): Promise<PaginateResponseVo<FeedFindOneVo>> {
    const page = feedListDto?.page;
    const limit = feedListDto?.limit;
    const offset = (page - 1) * limit;

    const feeds = this.feedRepository
      .createQueryBuilder('feed')
      .leftJoinAndSelect('feed.user', 'user')
      .select([
        'feed.id',
        'feed.userId',
        'feed.description',
        'feed.status',
        'feed.likeCount',
        'feed.commentCount',
        'feed.showLikeCountYn',
        'feed.createdAt',
        'feed.updatedAt',
        'user.id',
        'user.username',
        'user.nickname',
        'user.profileImage',
      ])
      .where('feed.displayYn = :displayYn', { displayYn: YN.Y })
      .andWhere('feed.status = :status', { status: FEED_STATUS.ACTIVE })
      .andWhere('feed.userId = :userId', { userId: userId })
      .orderBy('feed.createdAt', 'DESC')
      .offset(offset)
      .limit(limit);

    const [items, totalCount] = await feeds.getManyAndCount();
    const lasPage = Math.ceil(totalCount / limit);

    for (const item of items) {
      item.feedImages = await FeedImage.createQueryBuilder('feedImage')
        .where('feedImage.feedId = :feedId', { feedId: item.id })
        .getMany();
    }

    return {
      items: items,
      totalCount: totalCount,
      pageInfo: {
        page,
        limit,
        isLast: page === lasPage ? true : false,
      },
    };
  }

```


### 피드 생성
-  피드 Repositry 에서 typeorm을 활용한 로직 구현
-  피드 생성시 FEED IMAGE 테이블에 `feed_id` 로 매핑한 row 추가
-  피드 생성시 USER 테이블에 `feed_count` 증가  -> leftJoin으로 인한 쿼리부하 방지 (반대로 삭제시 count 감소 시켜주기)
```ts
 /**
   *  피드 생성
   * @param userId
   * @param feedCreateDto
   * @returns Feed
   */
  public async createFeed(
    userId: number,
    feedCreateDto: FeedCreateDto,
  ): Promise<Feed> {
    const feed = await dataSource.transaction(async (transaction) => {
      let newFeed = new Feed(feedCreateDto);
      newFeed.userId = userId;
      newFeed = await transaction.save(newFeed);
      // TODO: feed image  생성
      if (feedCreateDto.feedImages && feedCreateDto.feedImages.length > 0) {
        await Promise.all(
          feedCreateDto.feedImages.map(async (image) => {
            let newImage = new FeedImage().set({
              feedId: newFeed.id,
              image: image.image,
              sortOrder: image.sortOrder,
            });
            newImage = await transaction.save(newImage);
          }),
        );
      }
      // TODO: user feed count 증가
      let user = await this.userRepository.findOne({
        where: { id: userId },
      });

      user.feedCount++;
      user = await transaction.save(user);
      // TODO: description 에 tag 있는 경우 tag, mapper_feed_tag 테이블 생성

      return newFeed;
    });

    return feed;
  }
```

## 🐳 공유사항
-  제가 검색해가면서 구현한 부분이라 미흡할 수도 있습니다. 참고만 해보시고 문의사항 있으면 문의주셔요!