### PR TITLE
feat: 태그별 피드 목록 로직 추가

### DIFF
--- a/src/modules/feed/dto/feed-list.dto.ts
+++ b/src/modules/feed/dto/feed-list.dto.ts
@@ -8,9 +8,4 @@ export class FeedListDto extends BasePaginationDto<FeedListDto> {
   @IsOptional()
   @Expose()
   tagName?: string;
-
-  @ApiPropertyOptional()
-  @IsOptional()
-  @Expose()
-  userId?: number;
 }

--- a/src/modules/feed/feed.controller.ts
+++ b/src/modules/feed/feed.controller.ts
@@ -40,6 +40,30 @@ export class FeedController {
     );
   }
 
+  @Get('/feed/tag')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(new UserGuard())
+  public async findAllByTag(
+    @UserInfo() user: User,
+    @Query() feedListDto: FeedListDto,
+  ): Promise<BaseResponseVo<PaginateResponseVo<FeedFindOneVo>>> {
+    return new BaseResponseVo<PaginateResponseVo<FeedFindOneVo>>(
+      await this.feedService.findAllByTag(user, feedListDto),
+    );
+  }
+
+  @Get('/feed/following')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(new UserGuard())
+  public async findAllByFollowing(
+    @UserInfo() user: User,
+    @Query() feedListDto: FeedListDto,
+  ): Promise<BaseResponseVo<PaginateResponseVo<FeedFindOneVo>>> {
+    return new BaseResponseVo<PaginateResponseVo<FeedFindOneVo>>(
+      await this.feedService.findAllByFollowing(user, feedListDto),
+    );
+  }
+
   @Get('/feed/user/:username')
   @HttpCode(HttpStatus.OK)
   public async findAllByUser(

--- a/src/modules/feed/feed.entity.ts
+++ b/src/modules/feed/feed.entity.ts
@@ -1,9 +1,18 @@
 import { IsEnum, IsNotEmpty } from 'class-validator';
 import { FEED_STATUS, YN } from 'src/common';
 import { BaseUpdateEntity } from 'src/core';
-import { Column, Entity, JoinColumn, OneToMany, OneToOne } from 'typeorm';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  JoinTable,
+  ManyToMany,
+  OneToMany,
+  OneToOne,
+} from 'typeorm';
 import { User } from '../user/user.entity';
 import { FeedImage } from '../feed-image/feed-image.entity';
+import { Tag } from '../tag/tag.entity';
 
 @Entity({ name: 'feed' })
 export class Feed extends BaseUpdateEntity<Feed> {
@@ -58,6 +67,18 @@ export class Feed extends BaseUpdateEntity<Feed> {
 
   @OneToMany((type) => FeedImage, (feedImages) => feedImages.feed)
   feedImages?: FeedImage[];
+
+  @ManyToMany((type) => Tag, (tag) => tag.feeds)
+  @JoinTable({
+    name: 'mapper_feed_tag',
+    joinColumn: {
+      name: 'feed_id',
+    },
+    inverseJoinColumn: {
+      name: 'tag_id',
+    },
+  })
+  tags?: Tag[];
 
   // no database
   likedYn?: boolean;

--- a/src/modules/feed/feed.service.ts
+++ b/src/modules/feed/feed.service.ts
@@ -27,6 +27,27 @@ export class FeedService {
     return feeds;
   }
 
+  public async findAllByTag(
+    user: User,
+    feedListDto?: FeedListDto,
+  ): Promise<PaginateResponseVo<FeedFindOneVo>> {
+    const feeds = await this.feedRepository.findAllByTag(user, feedListDto);
+    if (!feeds) throw new NotFoundException();
+    return feeds;
+  }
+
+  public async findAllByFollowing(
+    user: User,
+    feedListDto?: FeedListDto,
+  ): Promise<PaginateResponseVo<FeedFindOneVo>> {
+    const feeds = await this.feedRepository.findAllByFollowing(
+      user,
+      feedListDto,
+    );
+    if (!feeds) throw new NotFoundException();
+    return feeds;
+  }
+
   public async findAllByUser(
     username: string,
     feedListDto?: FeedListDto,

--- a/src/modules/feed/vo/feed-find-one.vo.ts
+++ b/src/modules/feed/vo/feed-find-one.vo.ts
@@ -2,6 +2,7 @@ import { FEED_STATUS, GENDER, USER_STATUS, YN } from 'src/common';
 import { Feed } from '../feed.entity';
 import { User } from 'src/modules/user/user.entity';
 import { FeedImage } from 'src/modules/feed-image/feed-image.entity';
+import { Tag } from 'src/modules/tag/tag.entity';
 
 export class FeedFindOneVo implements Partial<Feed> {
   id: number;
@@ -12,6 +13,7 @@ export class FeedFindOneVo implements Partial<Feed> {
   likeCount: number;
   commentCount: number;
   showLikeCountYn?: YN;
+  tags?: Tag[];
   status?: FEED_STATUS;
   createdAt?: Date;
   updatedAt?: Date;

--- a/src/modules/tag/tag.entity.ts
+++ b/src/modules/tag/tag.entity.ts
@@ -1,6 +1,7 @@
 import { YN } from 'src/common';
 import { BaseEntity } from 'src/core';
-import { Column, Entity } from 'typeorm';
+import { Column, Entity, JoinTable, ManyToMany } from 'typeorm';
+import { Feed } from '../feed/feed.entity';
 
 @Entity({ name: 'tag' })
 export class Tag extends BaseEntity<Tag> {
@@ -18,4 +19,16 @@ export class Tag extends BaseEntity<Tag> {
     default: YN.Y,
   })
   searchYn?: YN;
+
+  @ManyToMany((type) => Feed, (feed) => feed.tags)
+  @JoinTable({
+    name: 'mapper_feed_tag',
+    joinColumn: {
+      name: 'tag_id',
+    },
+    inverseJoinColumn: {
+      name: 'feed_id',
+    },
+  })
+  feeds?: Tag[];
 }


### PR DESCRIPTION
## 🐳 개요
태그별 피드 목록 로직 추가

## 🐳 작업사항
- `mapper_feed_tag` 테이블을 기준으로 `feed` 와 `tag` 테이블을 조인
- feed.tags 배열의 `tagName` 값들과 클라이언서 넘긴 `tagName` 파라미터를 비교하는 where문 추가

