### PR TITLE
refactor: 피드 좋아요 수 노출 여부, 피드 보관 및 피드 삭제 로직 및 코드 리팩토링

### DIFF
--- a/src/common/decorator/default.decorator.ts
+++ b/src/common/decorator/default.decorator.ts
@@ -1,0 +1,5 @@
+import { Transform } from 'class-transformer';
+
+export const Default = (defaultValue: any): PropertyDecorator => {
+  return Transform(({ value }) => value || defaultValue);
+};

--- a/src/common/decorator/index.ts
+++ b/src/common/decorator/index.ts
@@ -1,3 +1,4 @@
 export * from './is-password-validator.decorator';
 export * from './is-equal-to.decorator';
 export * from './user.decorator';
+export * from './default.decorator';

--- a/src/core/dto/base-pagination.dto.ts
+++ b/src/core/dto/base-pagination.dto.ts
@@ -1,23 +1,27 @@
-import { Expose, Type } from 'class-transformer';
+import { Expose, Transform, Type } from 'class-transformer';
 import { BaseDto } from './base.dto';
 import { IsEnum, IsNumber, IsOptional, Max, Min } from 'class-validator';
 import { ORDER_BY_VALUE } from 'src/common';
+import { Default } from 'src/common/decorator/default.decorator';
 
 export class BasePaginationDto<T> extends BaseDto<T> {
   @Type(() => Number)
   @Min(1)
+  @Default(1)
   @Expose()
-  page: number = 1;
+  page: number;
 
   @Type(() => Number)
   @Max(10)
+  @Default(10)
   @Expose()
-  limit: number = 10;
+  limit: number;
 
   @IsOptional()
   @IsEnum(ORDER_BY_VALUE, { each: true })
+  @Default(ORDER_BY_VALUE.DESC)
   @Expose()
-  orderBy?: ORDER_BY_VALUE = ORDER_BY_VALUE.DESC;
+  orderBy?: ORDER_BY_VALUE;
 
   @IsOptional()
   @Expose()

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -2,3 +2,5 @@ export * from './dto';
 export * from './entity';
 export * from './vo';
 export * from './guard';
+export * from './utils';
+export * from './typeorm';

--- a/src/core/typeorm/index.ts
+++ b/src/core/typeorm/index.ts
@@ -1,0 +1,1 @@
+export * from './select-query-builder.declaration';

--- a/src/core/typeorm/select-query-builder.declaration.ts
+++ b/src/core/typeorm/select-query-builder.declaration.ts
@@ -16,6 +16,5 @@ SelectQueryBuilder.prototype.Paginate = function <Entity, T>(
   pagination: BasePaginationDto<T>,
 ): SelectQueryBuilder<Entity> {
   this.offset((pagination.page - 1) * pagination.limit).limit(pagination.limit);
-  console.log(this, pagination);
   return this;
 };

--- a/src/core/typeorm/select-query-builder.declaration.ts
+++ b/src/core/typeorm/select-query-builder.declaration.ts
@@ -1,0 +1,21 @@
+import { SelectQueryBuilder } from 'typeorm/query-builder/SelectQueryBuilder';
+import { BasePaginationDto } from '../dto';
+import { FeedListDto } from 'src/modules/feed/dto';
+
+declare module 'typeorm/query-builder/SelectQueryBuilder' {
+  interface SelectQueryBuilder<Entity> {
+    Paginate<Entity, T>(
+      this: SelectQueryBuilder<Entity>,
+      pagination: BasePaginationDto<T>,
+    ): SelectQueryBuilder<Entity>;
+  }
+}
+
+SelectQueryBuilder.prototype.Paginate = function <Entity, T>(
+  this: SelectQueryBuilder<Entity>,
+  pagination: BasePaginationDto<T>,
+): SelectQueryBuilder<Entity> {
+  this.offset((pagination.page - 1) * pagination.limit).limit(pagination.limit);
+  console.log(this, pagination);
+  return this;
+};

--- a/src/core/utils/generate-paginated-response.util.ts
+++ b/src/core/utils/generate-paginated-response.util.ts
@@ -1,0 +1,20 @@
+import { PaginateResponseVo } from '../vo';
+
+export const generatePaginatedResponse = <T>(
+  items: T[],
+  totalCount: number,
+  page: number,
+  limit: number,
+): PaginateResponseVo<T> => {
+  const lasPage = Math.ceil(totalCount / limit);
+
+  return {
+    items: items,
+    totalCount: totalCount,
+    pageInfo: {
+      page,
+      limit,
+      isLast: page === lasPage ? true : false,
+    },
+  };
+};

--- a/src/core/utils/index.ts
+++ b/src/core/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './generate-paginated-response.util';

--- a/src/modules/feed/dto/feed-list.dto.ts
+++ b/src/modules/feed/dto/feed-list.dto.ts
@@ -1,6 +1,7 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Expose } from 'class-transformer';
 import { IsOptional } from 'class-validator';
+import { Default, FEED_STATUS } from 'src/common';
 import { BasePaginationDto } from 'src/core';
 
 export class FeedListDto extends BasePaginationDto<FeedListDto> {
@@ -8,4 +9,10 @@ export class FeedListDto extends BasePaginationDto<FeedListDto> {
   @IsOptional()
   @Expose()
   tagName?: string;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @Default(FEED_STATUS.ACTIVE)
+  @Expose()
+  status?: FEED_STATUS;
 }

--- a/src/modules/feed/dto/feed-update-status.dto.ts
+++ b/src/modules/feed/dto/feed-update-status.dto.ts
@@ -1,0 +1,25 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Expose } from 'class-transformer';
+import { IsEnum, IsOptional } from 'class-validator';
+import { Default, FEED_STATUS, YN } from 'src/common';
+
+export class FeedUpdateStatusDto {
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsEnum(YN, { each: true })
+  @Default(YN.Y)
+  @Expose()
+  showLikeCountYn?: YN;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsEnum(YN, { each: true })
+  @Expose()
+  displayYn?: YN;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsEnum(FEED_STATUS, { each: true })
+  @Expose()
+  status?: FEED_STATUS;
+}

--- a/src/modules/feed/dto/feed-update.dto.ts
+++ b/src/modules/feed/dto/feed-update.dto.ts
@@ -27,23 +27,4 @@ export class FeedUpdateDto
   @IsOptional()
   @Expose()
   newFeedImages?: FeedImage[];
-
-  @ApiPropertyOptional()
-  @IsOptional()
-  @IsEnum(YN, { each: true })
-  @Default(YN.Y)
-  @Expose()
-  showLikeCountYn?: YN;
-
-  @ApiPropertyOptional()
-  @IsOptional()
-  @IsEnum(YN, { each: true })
-  @Expose()
-  displayYn?: YN;
-
-  @ApiPropertyOptional()
-  @IsOptional()
-  @IsEnum(FEED_STATUS, { each: true })
-  @Expose()
-  status?: FEED_STATUS;
 }

--- a/src/modules/feed/dto/feed-update.dto.ts
+++ b/src/modules/feed/dto/feed-update.dto.ts
@@ -3,7 +3,7 @@ import { Feed } from '../feed.entity';
 import { ApiPropertyOptional } from '@nestjs/swagger';
 import { IsEnum, IsOptional, MinLength } from 'class-validator';
 import { Expose, Transform } from 'class-transformer';
-import { GENDER } from 'src/common';
+import { Default, FEED_STATUS, YN } from 'src/common';
 import { FeedImage } from 'src/modules/feed-image/feed-image.entity';
 
 export class FeedUpdateDto
@@ -27,4 +27,23 @@ export class FeedUpdateDto
   @IsOptional()
   @Expose()
   newFeedImages?: FeedImage[];
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsEnum(YN, { each: true })
+  @Default(YN.Y)
+  @Expose()
+  showLikeCountYn?: YN;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsEnum(YN, { each: true })
+  @Expose()
+  displayYn?: YN;
+
+  @ApiPropertyOptional()
+  @IsOptional()
+  @IsEnum(FEED_STATUS, { each: true })
+  @Expose()
+  status?: FEED_STATUS;
 }

--- a/src/modules/feed/dto/index.ts
+++ b/src/modules/feed/dto/index.ts
@@ -1,3 +1,4 @@
 export * from './feed-create.dto';
 export * from './feed-update.dto';
+export * from './feed-update-status.dto';
 export * from './feed-list.dto';

--- a/src/modules/feed/feed.controller.ts
+++ b/src/modules/feed/feed.controller.ts
@@ -171,11 +171,12 @@ export class FeedController {
   @HttpCode(HttpStatus.OK)
   @UseGuards(new UserGuard())
   public async updateFeed(
-    @UserInfo() user: User,
     @Param('id', ParseIntPipe) id: number,
     @Body() feedUpdateDto: FeedUpdateDto,
-  ): Promise<FeedFindOneVo> {
-    return await this.feedService.updateFeed(id, feedUpdateDto);
+  ): Promise<BaseResponseVo<FeedFindOneVo>> {
+    return new BaseResponseVo<FeedFindOneVo>(
+      await this.feedService.updateFeed(id, feedUpdateDto),
+    );
   }
 
   // DELETE ENDPOINTS

--- a/src/modules/feed/feed.controller.ts
+++ b/src/modules/feed/feed.controller.ts
@@ -89,7 +89,7 @@ export class FeedController {
     @Query() feedListDto: FeedListDto,
   ): Promise<BaseResponseVo<PaginateResponseVo<FeedFindOneVo>>> {
     return new BaseResponseVo<PaginateResponseVo<FeedFindOneVo>>(
-      await this.feedService.findAllByBookmark(user.id, feedListDto),
+      await this.feedService.findAllByBookmark(user, feedListDto),
     );
   }
 
@@ -101,9 +101,13 @@ export class FeedController {
 
   @Get('/feed/:id([0-9]+)')
   @HttpCode(HttpStatus.OK)
-  public async findOneFeed(@Param('id', ParseIntPipe) id: number) {
+  @UseGuards(new UserGuard())
+  public async findOneFeed(
+    @UserInfo() user: User,
+    @Param('id', ParseIntPipe) id: number,
+  ) {
     return new BaseResponseVo<FeedFindOneVo>(
-      await this.feedService.findOne(id),
+      await this.feedService.findOneByUser(user, id),
     );
   }
 
@@ -185,8 +189,11 @@ export class FeedController {
   @Delete('/feed/:id([0-9]+)')
   @HttpCode(HttpStatus.OK)
   @UseGuards(new UserGuard())
-  public async deleteFeed(@Param('id', ParseIntPipe) id: number) {
-    return await this.feedService.deleteFeed(id);
+  public async deleteFeed(
+    @UserInfo() user: User,
+    @Param('id', ParseIntPipe) id: number,
+  ) {
+    return await this.feedService.deleteFeed(user.id, id);
   }
 
   /**

--- a/src/modules/feed/feed.controller.ts
+++ b/src/modules/feed/feed.controller.ts
@@ -185,11 +185,8 @@ export class FeedController {
   @Delete('/feed/:id([0-9]+)')
   @HttpCode(HttpStatus.OK)
   @UseGuards(new UserGuard())
-  public async deleteFeed(
-    @UserInfo() user: User,
-    @Param('id', ParseIntPipe) id: number,
-  ) {
-    return await this.feedService.deleteFeed(user.id, id);
+  public async deleteFeed(@Param('id', ParseIntPipe) id: number) {
+    return await this.feedService.deleteFeed(id);
   }
 
   /**

--- a/src/modules/feed/feed.controller.ts
+++ b/src/modules/feed/feed.controller.ts
@@ -19,7 +19,12 @@ import { BaseResponseVo, PaginateResponseVo, UserGuard } from 'src/core';
 import { FeedFindOneVo } from './vo';
 import { UserInfo } from 'src/common';
 import { User } from '../user/user.entity';
-import { FeedCreateDto, FeedListDto, FeedUpdateDto } from './dto';
+import {
+  FeedCreateDto,
+  FeedListDto,
+  FeedUpdateDto,
+  FeedUpdateStatusDto,
+} from './dto';
 
 @Controller()
 @ApiTags('FEED')
@@ -176,6 +181,40 @@ export class FeedController {
   ): Promise<BaseResponseVo<FeedFindOneVo>> {
     return new BaseResponseVo<FeedFindOneVo>(
       await this.feedService.updateFeed(id, feedUpdateDto),
+    );
+  }
+
+  /**
+   * 피드 상태 업데이트
+   * @param feedUpdateStatusDto
+   * @returns Feed
+   */
+  @Patch('/feed/:id([0-9]+)/status')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(new UserGuard())
+  public async updateFeedStatus(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() feedUpdateStatusDto: FeedUpdateStatusDto,
+  ): Promise<BaseResponseVo<FeedFindOneVo>> {
+    return new BaseResponseVo<FeedFindOneVo>(
+      await this.feedService.updateFeedStatus(id, feedUpdateStatusDto),
+    );
+  }
+
+  /**
+   * 피드 좋아요 수 노출 상태 업데이트
+   * @param feedUpdateStatusDto
+   * @returns Feed
+   */
+  @Patch('/feed/:id([0-9]+)/show-like-count')
+  @HttpCode(HttpStatus.OK)
+  @UseGuards(new UserGuard())
+  public async updateShowLikeCount(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() feedUpdateStatusDto: FeedUpdateStatusDto,
+  ): Promise<BaseResponseVo<FeedFindOneVo>> {
+    return new BaseResponseVo<FeedFindOneVo>(
+      await this.feedService.updateShowLikeCount(id, feedUpdateStatusDto),
     );
   }
 

--- a/src/modules/feed/feed.repository.ts
+++ b/src/modules/feed/feed.repository.ts
@@ -6,7 +6,7 @@ import { FeedFindOneVo } from './vo';
 import { FEED_STATUS, ORDER_BY_VALUE, YN } from 'src/common';
 import { FeedCreateDto, FeedListDto, FeedUpdateDto } from './dto';
 import { FeedImage } from '../feed-image/feed-image.entity';
-import { PaginateResponseVo } from 'src/core';
+import { PaginateResponseVo, generatePaginatedResponse } from 'src/core';
 import { User } from '../user/user.entity';
 import { FeedLike } from '../feed-like/feed-like.entity';
 import { FeedBookmark } from '../feed-bookmark/feed-bookmark.entity';
@@ -32,68 +32,27 @@ export class FeedRepository {
     user: User,
     feedListDto?: FeedListDto,
   ): Promise<PaginateResponseVo<FeedFindOneVo>> {
-    const page = feedListDto?.page;
-    const limit = feedListDto?.limit;
-    const offset = (page - 1) * limit;
-
     const feeds = this.feedRepository
       .createQueryBuilder('feed')
       .leftJoinAndSelect('feed.user', 'user')
       .where('user.delYn = :delYn', { delYn: YN.N })
       .andWhere('feed.displayYn = :displayYn', { displayYn: YN.Y })
       .andWhere('feed.status = :status', { status: FEED_STATUS.ACTIVE })
-      .orderBy('feed.createdAt', 'DESC')
-      .offset(offset)
-      .limit(limit);
+      .orderBy('feed.createdAt', ORDER_BY_VALUE.DESC)
+      .Paginate(feedListDto);
 
     const [items, totalCount] = await feeds.getManyAndCount();
-    const lasPage = Math.ceil(totalCount / limit);
 
     for (const item of items) {
-      item.feedImages = await FeedImage.createQueryBuilder('feedImage')
-        .where('feedImage.feedId = :feedId', { feedId: item.id })
-        .getMany();
-
-      // * 좋아요 체크 여부
-      if (user.id) {
-        const liked = await FeedLike.createQueryBuilder('feedLike')
-          .where('feedLike.feedId = :feedId', { feedId: item.id })
-          .andWhere('feedLike.userId = :userId', {
-            userId: user.id,
-          })
-          .getOne();
-        if (liked) {
-          item.likedYn = true;
-        } else {
-          item.likedYn = false;
-        }
-      }
-
-      // * 북마크 체크 여부
-      if (user.id) {
-        const liked = await FeedBookmark.createQueryBuilder('feedBookmark')
-          .where('feedBookmark.feedId = :feedId', { feedId: item.id })
-          .andWhere('feedBookmark.userId = :userId', {
-            userId: user.id,
-          })
-          .getOne();
-        if (liked) {
-          item.bookmarkedYn = true;
-        } else {
-          item.bookmarkedYn = false;
-        }
-      }
+      await this.processFeedItem(user.id, item);
     }
 
-    return {
-      items: items,
-      totalCount: totalCount,
-      pageInfo: {
-        page,
-        limit,
-        isLast: page === lasPage ? true : false,
-      },
-    };
+    return generatePaginatedResponse(
+      items,
+      totalCount,
+      feedListDto.page,
+      feedListDto.limit,
+    );
   }
 
   /**
@@ -104,10 +63,6 @@ export class FeedRepository {
     user: User,
     feedListDto?: FeedListDto,
   ): Promise<PaginateResponseVo<FeedFindOneVo>> {
-    const page = feedListDto?.page;
-    const limit = feedListDto?.limit;
-    const offset = (page - 1) * limit;
-
     const feeds = this.feedRepository
       .createQueryBuilder('feed')
       .innerJoinAndSelect('feed.user', 'user')
@@ -115,63 +70,29 @@ export class FeedRepository {
       .where('user.delYn = :delYn', { delYn: YN.N })
       .andWhere('feed.displayYn = :displayYn', { displayYn: YN.Y })
       .andWhere('feed.status = :status', { status: FEED_STATUS.ACTIVE })
-      .orderBy('feed.createdAt', 'DESC');
+      .orderBy('feed.createdAt', ORDER_BY_VALUE.DESC);
 
     const filteredFeeds: Feed[] = (await feeds.getMany()).filter((feed) =>
       feed.tags.some((tag) => tag.tagName === feedListDto.tagName),
     );
 
-    const paginatedFeeds = filteredFeeds.slice(offset, offset + limit);
-
+    const offset = (feedListDto.page - 1) * feedListDto.limit;
+    const paginatedFeeds = filteredFeeds.slice(
+      offset,
+      offset + feedListDto.limit,
+    );
     const [items, totalCount] = [paginatedFeeds, filteredFeeds.length];
 
-    const lasPage = Math.ceil(totalCount / limit);
-
     for (const item of filteredFeeds) {
-      item.feedImages = await FeedImage.createQueryBuilder('feedImage')
-        .where('feedImage.feedId = :feedId', { feedId: item.id })
-        .getMany();
-
-      // * 좋아요 체크 여부
-      if (user.id) {
-        const liked = await FeedLike.createQueryBuilder('feedLike')
-          .where('feedLike.feedId = :feedId', { feedId: item.id })
-          .andWhere('feedLike.userId = :userId', {
-            userId: user.id,
-          })
-          .getOne();
-        if (liked) {
-          item.likedYn = true;
-        } else {
-          item.likedYn = false;
-        }
-      }
-
-      // * 북마크 체크 여부
-      if (user.id) {
-        const liked = await FeedBookmark.createQueryBuilder('feedBookmark')
-          .where('feedBookmark.feedId = :feedId', { feedId: item.id })
-          .andWhere('feedBookmark.userId = :userId', {
-            userId: user.id,
-          })
-          .getOne();
-        if (liked) {
-          item.bookmarkedYn = true;
-        } else {
-          item.bookmarkedYn = false;
-        }
-      }
+      await this.processFeedItem(user.id, item);
     }
 
-    return {
-      items: items,
-      totalCount: totalCount,
-      pageInfo: {
-        page,
-        limit,
-        isLast: page === lasPage ? true : false,
-      },
-    };
+    return generatePaginatedResponse(
+      items,
+      totalCount,
+      feedListDto.page,
+      feedListDto.limit,
+    );
   }
 
   /**
@@ -182,88 +103,30 @@ export class FeedRepository {
     user: User,
     feedListDto?: FeedListDto,
   ): Promise<PaginateResponseVo<FeedFindOneVo>> {
-    const page = feedListDto?.page;
-    const limit = feedListDto?.limit;
-    const offset = (page - 1) * limit;
-
     const feeds = this.feedRepository
       .createQueryBuilder('feed')
       .leftJoinAndSelect('feed.user', 'user')
-      .select([
-        'feed.id',
-        'feed.userId',
-        'feed.description',
-        'feed.status',
-        'feed.likeCount',
-        'feed.commentCount',
-        'feed.showLikeCountYn',
-        'feed.createdAt',
-        'feed.updatedAt',
-        'user.id',
-        'user.username',
-        'user.nickname',
-        'user.profileImage',
-      ])
       .where('feed.userId IN (:...userId)', {
         userId: [...user.followingIds, user.id],
       })
       .andWhere('user.delYn = :delYn', { delYn: YN.N })
       .andWhere('feed.displayYn = :displayYn', { displayYn: YN.Y })
       .andWhere('feed.status = :status', { status: FEED_STATUS.ACTIVE })
-      .orderBy('feed.createdAt', 'DESC')
-      .offset(offset)
-      .limit(limit);
+      .orderBy('feed.createdAt', ORDER_BY_VALUE.DESC)
+      .Paginate(feedListDto);
 
     const [items, totalCount] = await feeds.getManyAndCount();
-    const lasPage = Math.ceil(totalCount / limit);
 
     for (const item of items) {
-      item.feedImages = await FeedImage.createQueryBuilder('feedImage')
-        .where('feedImage.feedId = :feedId', { feedId: item.id })
-        .getMany();
-
-      // * 좋아요 체크 여부
-      if (user.id) {
-        const liked = await FeedLike.createQueryBuilder('feedLike')
-          .where('feedLike.feedId = :feedId', { feedId: item.id })
-          .andWhere('feedLike.userId = :userId', {
-            userId: user.id,
-          })
-          .getOne();
-        if (liked) {
-          item.likedYn = true;
-        } else {
-          item.likedYn = false;
-        }
-      }
-
-      // * 북마크 체크 여부
-      if (user.id) {
-        const liked = await FeedBookmark.createQueryBuilder('feedBookmark')
-          .where('feedBookmark.feedId = :feedId', { feedId: item.id })
-          .andWhere('feedBookmark.userId = :userId', {
-            userId: user.id,
-          })
-          .getOne();
-        if (liked) {
-          item.bookmarkedYn = true;
-        } else {
-          item.bookmarkedYn = false;
-        }
-      }
-
-      // TODO: 좋아오 유저
+      await this.processFeedItem(user.id, item);
     }
 
-    return {
-      items: items,
-      totalCount: totalCount,
-      pageInfo: {
-        page,
-        limit,
-        isLast: page === lasPage ? true : false,
-      },
-    };
+    return generatePaginatedResponse(
+      items,
+      totalCount,
+      feedListDto.page,
+      feedListDto.limit,
+    );
   }
 
   /**
@@ -275,128 +138,91 @@ export class FeedRepository {
     userId: number,
     feedListDto?: FeedListDto,
   ): Promise<PaginateResponseVo<FeedFindOneVo>> {
-    const page = feedListDto?.page;
-    const limit = feedListDto?.limit;
-    const offset = (page - 1) * limit;
-
     const feeds = this.feedRepository
       .createQueryBuilder('feed')
       .leftJoinAndSelect('feed.user', 'user')
-      .select([
-        'feed.id',
-        'feed.userId',
-        'feed.description',
-        'feed.status',
-        'feed.likeCount',
-        'feed.commentCount',
-        'feed.showLikeCountYn',
-        'feed.createdAt',
-        'feed.updatedAt',
-        'user.id',
-        'user.username',
-        'user.nickname',
-        'user.profileImage',
-        'user.feedCount',
-      ])
       .where('feed.displayYn = :displayYn', { displayYn: YN.Y })
       .andWhere('feed.status = :status', { status: FEED_STATUS.ACTIVE })
       .andWhere('feed.userId = :userId', { userId: userId })
-      .orderBy('feed.createdAt', 'DESC')
-      .offset(offset)
-      .limit(limit);
+      .orderBy('feed.createdAt', ORDER_BY_VALUE.DESC)
+      .Paginate(feedListDto);
 
     const [items, totalCount] = await feeds.getManyAndCount();
-    const lasPage = Math.ceil(totalCount / limit);
 
     for (const item of items) {
-      item.feedImages = await FeedImage.createQueryBuilder('feedImage')
-        .where('feedImage.feedId = :feedId', { feedId: item.id })
-        .getMany();
+      await this.processFeedItem(userId, item);
     }
 
-    return {
-      items: items,
-      totalCount: totalCount,
-      pageInfo: {
-        page,
-        limit,
-        isLast: page === lasPage ? true : false,
-      },
-    };
+    return generatePaginatedResponse(
+      items,
+      totalCount,
+      feedListDto.page,
+      feedListDto.limit,
+    );
   }
 
   /**
-   * 유저별 피드 목록
+   * 유저별 북마크 피드 목록
    * @param userId
    * @returns
    */
   public async findAllByBookmark(
-    userId: number,
+    user: User,
     feedListDto?: FeedListDto,
   ): Promise<PaginateResponseVo<FeedFindOneVo>> {
-    const page = feedListDto?.page;
-    const limit = feedListDto?.limit;
-    const offset = (page - 1) * limit;
-
     const feeds = FeedBookmark.createQueryBuilder('feedBookmark')
       .leftJoinAndSelect('feedBookmark.feed', 'feed')
       .where('feed.displayYn = :displayYn', { displayYn: YN.Y })
       .andWhere('feed.status = :status', { status: FEED_STATUS.ACTIVE })
-      .andWhere('feedBookmark.userId = :userId', { userId: userId })
+      .andWhere('feedBookmark.userId = :userId', { userId: user.id })
       .orderBy('feed.createdAt', ORDER_BY_VALUE.DESC)
-      .offset(offset)
-      .limit(limit);
+      .Paginate(feedListDto);
 
     const [items, totalCount] = await feeds.getManyAndCount();
-    const lasPage = Math.ceil(totalCount / limit);
 
     for (const item of items) {
-      item.feed.feedImages = await FeedImage.createQueryBuilder('feedImage')
-        .where('feedImage.feedId = :feedId', { feedId: item.feedId })
-        .getMany();
+      await this.processFeedItem(user.id, item.feed);
     }
 
-    return {
-      items: items.map((item) => item.feed),
-      totalCount: totalCount,
-      pageInfo: {
-        page,
-        limit,
-        isLast: page === lasPage ? true : false,
-      },
-    };
+    return generatePaginatedResponse(
+      items.map((item) => item.feed),
+      totalCount,
+      feedListDto.page,
+      feedListDto.limit,
+    );
   }
 
   /**
-   * 피드 상세
-   * @param id
+   * 피드 아이디로 찾기
+   * @param ID
    * @returns FeedFindOneVo
    */
-  public async findOneFeed(id: number): Promise<FeedFindOneVo> {
+  public async findOneFeed(feedId: number): Promise<FeedFindOneVo> {
     const feed = await this.feedRepository
       .createQueryBuilder('feed')
       .leftJoinAndSelect('feed.user', 'user')
-      .select([
-        'feed.id',
-        'feed.userId',
-        'feed.description',
-        'feed.status',
-        'feed.likeCount',
-        'feed.commentCount',
-        'feed.showLikeCountYn',
-        'feed.createdAt',
-        'feed.updatedAt',
-        'user.id',
-        'user.username',
-        'user.nickname',
-        'user.profileImage',
-      ])
-      .where('feed.id = :id', { id: id })
+      .where('feed.id = :id', { id: feedId })
       .getOne();
 
-    feed.feedImages = await FeedImage.createQueryBuilder('feedImage')
-      .where('feedImage.feedId = :feedId', { feedId: feed.id })
-      .getMany();
+    return feed;
+  }
+
+  /**
+   * 유저별 피드 상세
+   * @param id
+   * @returns FeedFindOneVo
+   */
+  public async findOneByUser(
+    user: User,
+    feedId: number,
+  ): Promise<FeedFindOneVo> {
+    const feed = await this.feedRepository
+      .createQueryBuilder('feed')
+      .leftJoinAndSelect('feed.user', 'user')
+      .where('feed.id = :id', { id: feedId })
+      .getOne();
+
+    await this.processFeedItem(user.id, feed);
 
     return feed;
   }
@@ -473,7 +299,11 @@ export class FeedRepository {
     return feed;
   }
 
-  /** 피드 좋아요 */
+  /**
+   * 피드 좋아요
+   * @param userId
+   * @param feedId
+   */
   public async likeFeed(userId: number, feedId: number) {
     await dataSource.transaction(async (transaction) => {
       let newLike = new FeedLike().set({
@@ -488,7 +318,11 @@ export class FeedRepository {
     });
   }
 
-  /** 피드 북마크 */
+  /**
+   * 피드 북마크
+   * @param userId
+   * @param feedId
+   */
   public async bookmarkFeed(userId: number, feedId: number) {
     await dataSource.transaction(async (transaction) => {
       let newLike = new FeedBookmark().set({
@@ -550,15 +384,29 @@ export class FeedRepository {
    * @param feedId
    * @returns Feed
    */
-  public async deleteFeed(feedId: number): Promise<FeedFindOneVo> {
-    let feed = await this.feedRepository.findOne({
-      where: {
-        id: feedId,
-      },
+  public async deleteFeed(
+    userId: number,
+    feedId: number,
+  ): Promise<FeedFindOneVo> {
+    return await dataSource.transaction(async (transaction) => {
+      let feed = await this.feedRepository.findOne({
+        where: {
+          id: feedId,
+        },
+      });
+      feed.status = FEED_STATUS.DELETED;
+      feed = await transaction.save(feed);
+
+      // * USER FEED COUNT 감소
+      let user = await this.userRepository.findOne({
+        where: { id: userId },
+      });
+
+      user.feedCount--;
+      user = await transaction.save(user);
+
+      return feed;
     });
-    feed.status = FEED_STATUS.DELETED;
-    feed = await this.feedRepository.save(feed);
-    return feed;
   }
 
   /**
@@ -573,7 +421,27 @@ export class FeedRepository {
         .createQueryBuilder()
         .delete()
         .from(FeedImage)
-        .where('feedId = :feedId', { feedId: feedId })
+        .where('feedId = :feedId', { feedId })
+        .execute();
+
+      // * FEED LIKE 삭제
+      await dataSource
+        .createQueryBuilder()
+        .delete()
+        .from(FeedLike)
+        .where('feedId = :feedId', {
+          feedId,
+        })
+        .execute();
+
+      // * FEED BOOKMARK 삭제
+      await dataSource
+        .createQueryBuilder()
+        .delete()
+        .from(FeedBookmark)
+        .where('feedId = :feedId', {
+          feedId,
+        })
         .execute();
 
       // * FEED 삭제
@@ -594,7 +462,11 @@ export class FeedRepository {
     });
   }
 
-  /** 피드 좋아요 해제 */
+  /**
+   *  피드 좋아요 해제
+   * @param userId
+   * @param feedId
+   */
   public async deleteLikeFeed(userId: number, feedId: number) {
     await dataSource.transaction(async (transaction) => {
       await dataSource
@@ -611,7 +483,11 @@ export class FeedRepository {
     });
   }
 
-  /** 피드 북마크 해제 */
+  /**
+   * 피드 북마크 해제
+   * @param userId
+   * @param feedId
+   */
   public async deleteBookmarkFeed(userId: number, feedId: number) {
     await dataSource
       .createQueryBuilder()
@@ -620,5 +496,63 @@ export class FeedRepository {
       .where('feedId = :feedId', { feedId: feedId })
       .andWhere('userId = :userId', { userId: userId })
       .execute();
+  }
+
+  private async processFeedItem(
+    userId: number,
+    item: Feed,
+  ): Promise<FeedFindOneVo> {
+    item.feedImages = await this.__get_feed_images(item.id);
+
+    // * 좋아요 체크 여부
+    if (userId) {
+      const isLiked = await this.__get_feed_like_by_user(userId, item.id);
+      item.likedYn = isLiked;
+    }
+
+    // * 북마크 체크 여부
+    if (userId) {
+      const isBookmarked = await this.__get_feed_bookmark_by_user(
+        userId,
+        item.id,
+      );
+      item.bookmarkedYn = isBookmarked;
+    }
+
+    return item;
+  }
+
+  private async __get_feed_images(feedId: number) {
+    const feedImages = await FeedImage.createQueryBuilder('feedImage')
+      .where('feedImage.feedId = :feedId', { feedId })
+      .getMany();
+    return feedImages;
+  }
+
+  private async __get_feed_like_by_user(
+    userId: number,
+    feedId: number,
+  ): Promise<boolean> {
+    const feedLike = await FeedLike.createQueryBuilder('feedLike')
+      .where('feedLike.feedId = :feedId', { feedId })
+      .andWhere('feedLike.userId = :userId', {
+        userId,
+      })
+      .getExists();
+
+    return feedLike === true ? true : false;
+  }
+
+  private async __get_feed_bookmark_by_user(
+    userId: number,
+    feedId: number,
+  ): Promise<boolean> {
+    const feedBookmark = await FeedBookmark.createQueryBuilder('feedBookmark')
+      .where('feedBookmark.feedId = :feedId', { feedId })
+      .andWhere('feedBookmark.userId = :userId', {
+        userId,
+      })
+      .getExists();
+    return feedBookmark === true ? true : false;
   }
 }

--- a/src/modules/feed/feed.repository.ts
+++ b/src/modules/feed/feed.repository.ts
@@ -546,12 +546,27 @@ export class FeedRepository {
   }
 
   /**
-   *  피드 삭제
-   * @param userId
+   *  피드 삭제 (FEED STATUS => DELETED)
    * @param feedId
    * @returns Feed
    */
-  public async deleteFeed(userId: number, feedId: number) {
+  public async deleteFeed(feedId: number): Promise<FeedFindOneVo> {
+    let feed = await this.feedRepository.findOne({
+      where: {
+        id: feedId,
+      },
+    });
+    feed.status = FEED_STATUS.DELETED;
+    feed = await this.feedRepository.save(feed);
+    return feed;
+  }
+
+  /**
+   * 피드 영구 삭제
+   * @param userId
+   * @param feedId
+   */
+  public async hardDeleteFeed(userId: number, feedId: number) {
     await dataSource.transaction(async (transaction) => {
       // * FEED IMAGE 삭제
       await dataSource

--- a/src/modules/feed/feed.repository.ts
+++ b/src/modules/feed/feed.repository.ts
@@ -347,31 +347,18 @@ export class FeedRepository {
   ): Promise<FeedFindOneVo> {
     const feed = await dataSource.transaction(async (transaction) => {
       let feed = await this.findOneFeed(feedId);
-      // TODO: 기존 이미지 삭제하기
 
-      // TODO: 새로운 이미지 추가하기
-      // if (
-      //   feedUpdateDto.newFeedImages &&
-      //   feedUpdateDto.newFeedImages.length > 0
-      // ) {
-      //   await Promise.all(
-      //     feedUpdateDto.newFeedImages.map(async (image) => {
-      //       let newImage = new FeedImage().set({
-      //         feedId: feed.id,
-      //         image: image.image,
-      //         sortOrder: image.sortOrder,
-      //       });
-      //       newImage = await transaction.save(newImage);
-      //     }),
-      //   );
-      //   feedUpdateDto.feedImages = [
-      //     ...feedUpdateDto.feedImages,
-      //     ...feedUpdateDto.newFeedImages,
-      //   ];
-      // }
+      feed.showLikeCountYn = feedUpdateDto.showLikeCountYn;
+      feed.status = feedUpdateDto.status;
       feed.description = feedUpdateDto.description;
-      // feed.feedImages = feedUpdateDto.feedImages;
-      feed.updatedAt = new Date();
+
+      // * 피드 이미지 및 피드 설명글 수정 시에 updatedAt 변경
+      if (
+        feedUpdateDto.feedImages?.length > 0 ||
+        feedUpdateDto.description?.length > 0
+      ) {
+        feed.updatedAt = new Date();
+      }
       feed = await transaction.save(feed);
       return feed;
     });

--- a/src/modules/feed/feed.service.ts
+++ b/src/modules/feed/feed.service.ts
@@ -68,9 +68,9 @@ export class FeedService {
     return feeds;
   }
 
-  public async findAllByBookmark(userId: number, feedListDto?: FeedListDto) {
+  public async findAllByBookmark(user: User, feedListDto?: FeedListDto) {
     const feeds = await this.feedRepository.findAllByBookmark(
-      userId,
+      user,
       feedListDto,
     );
     if (!feeds) throw new NotFoundException();
@@ -78,12 +78,23 @@ export class FeedService {
   }
 
   /**
-   *
+   * 피드 찾기
    * @param id
    * @returns FeedFindOneVo
    */
   public async findOne(id: number): Promise<FeedFindOneVo> {
     const feed = await this.feedRepository.findOneFeed(id);
+    if (!feed) throw new NotFoundException();
+    return feed;
+  }
+
+  /**
+   * 사용자별 피드 상세
+   * @param id
+   * @returns FeedFindOneVo
+   */
+  public async findOneByUser(user: User, id: number): Promise<FeedFindOneVo> {
+    const feed = await this.feedRepository.findOneByUser(user, id);
     if (!feed) throw new NotFoundException();
     return feed;
   }
@@ -136,10 +147,10 @@ export class FeedService {
    * 피드 삭제 (FEED STATUS => DELETED)
    * @param userId
    */
-  public async deleteFeed(feedId: number) {
+  public async deleteFeed(userId: number, feedId: number) {
     const feed = await this.feedRepository.findOneFeed(feedId);
     if (!feed) throw new NotFoundException('존재하지 않는 게시물입니다');
-    return await this.feedRepository.deleteFeed(feedId);
+    return await this.feedRepository.deleteFeed(userId, feedId);
   }
 
   public async deleteLikeFeed(userId: number, feedId: number) {

--- a/src/modules/feed/feed.service.ts
+++ b/src/modules/feed/feed.service.ts
@@ -133,14 +133,13 @@ export class FeedService {
   // DELETE SERVICES
 
   /**
-   * 피드 삭제
+   * 피드 삭제 (FEED STATUS => DELETED)
    * @param userId
-   * @param feedId
    */
-  public async deleteFeed(userId: number, feedId: number) {
+  public async deleteFeed(feedId: number) {
     const feed = await this.feedRepository.findOneFeed(feedId);
     if (!feed) throw new NotFoundException('존재하지 않는 게시물입니다');
-    return await this.feedRepository.deleteFeed(userId, feedId);
+    return await this.feedRepository.deleteFeed(feedId);
   }
 
   public async deleteLikeFeed(userId: number, feedId: number) {

--- a/src/modules/feed/vo/feed-find-one.vo.ts
+++ b/src/modules/feed/vo/feed-find-one.vo.ts
@@ -1,4 +1,4 @@
-import { FEED_STATUS, GENDER, USER_STATUS, YN } from 'src/common';
+import { FEED_STATUS, YN } from 'src/common';
 import { Feed } from '../feed.entity';
 import { User } from 'src/modules/user/user.entity';
 import { FeedImage } from 'src/modules/feed-image/feed-image.entity';
@@ -14,6 +14,8 @@ export class FeedFindOneVo implements Partial<Feed> {
   commentCount: number;
   showLikeCountYn?: YN;
   tags?: Tag[];
+  likedYn?: boolean;
+  bookmarkedYn?: boolean;
   status?: FEED_STATUS;
   createdAt?: Date;
   updatedAt?: Date;


### PR DESCRIPTION
## 🐳 개요
피드 좋아요 수 노출 여부, 피드 보관 및 피드 삭제 로직 및 코드 리팩토링
close #32 
close #33 
close #36 
close #39 

## 🐳 작업사항
-  피드 좋아요 수 노출 여부 
   - `showLikeCount` 값으로 체크하여 반환
-  피브 보관
   - 기존 유저 별 피드 로직에서 dto `stauts` 값을 동적으로 받아 `FEED_STATUS.ARCHIVED` 로 조건을 걸어 보관된 피드 목록 반환
   - 피드 보관 및 보관 해제시 유저의 feedCount 의 값도 증가/감소 되게 처리  
- 피드 삭제 
   - 기존 hard delete 로직에서 `status` 값을   `FEED_STATUS.DELETED` 로 변경하였으며, 유저의 feedCount 또한 증가/감소 처리
   - hard delete 의 경우  피드 삭제시 관련된 코멘터리들도 다 삭제 할건지 등의 정책을 정하고 적용 필요

- 커스텀 데코리이터 작성
  - dto로 전달받는 프로퍼티의 default 값을 지정할 수 있도록 `class-transformer` 의 Transform 메서드를 이용해 커스텀 데코레이터 작성 
```tsx
  import { Transform } from 'class-transformer';
  
  export const Default = (defaultValue: any): PropertyDecorator => {
  return Transform(({ value }) => value || defaultValue);
  };
```
```tsx
export class BasePaginationDto<T> extends BaseDto<T> {
  @Type(() => Number)
  @Min(1)
  @Default(1)
  @Expose()
  page: number;

  @Type(() => Number)
  @Max(10)
  @Default(10)
  @Expose()
  limit: number;
}
```
