### PR TITLE
refactor: 로그인 & 로그아웃시 디바이스 ID 로직 추가 #37

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "reflect-metadata": "^0.1.13",
     "rxjs": "^7.2.0",
     "typeorm": "^0.3.15",
+    "useragent": "^2.3.0",
     "ws": "^8.14.2"
   },
   "devDependencies": {
@@ -60,6 +61,7 @@
     "@types/jest": "29.5.0",
     "@types/node": "18.15.11",
     "@types/supertest": "^2.0.11",
+    "@types/useragent": "^2.3.4",
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "eslint": "^8.0.1",

--- a/src/modules/auth/auth.service.ts
+++ b/src/modules/auth/auth.service.ts
@@ -35,7 +35,10 @@ export class AuthService {
    * @param authLoginDto
    * @returns AuthTokenVo
    */
-  public async login(authLoginDto: AuthLoginDto): Promise<AuthTokenVo> {
+  public async login(
+    authLoginDto: AuthLoginDto,
+    deviceId: string,
+  ): Promise<AuthTokenVo> {
     const user = await this.userRepository.findUserByEmail(authLoginDto.email);
     if (!user) throw new NotFoundException('User not found');
     // 비번 확인
@@ -54,10 +57,10 @@ export class AuthService {
       await this.userRepository.updateLoginDate(user.id);
 
       // * 유저 로그인 히스토리 생성
-      // TODO: device id
       const newLoginHistory = new UserLoginHistory({
         userId: user.id,
         actionType: USER_LOGIN.LOGIN,
+        deviceId: deviceId,
       });
 
       await this.userLoginHistoryRepository.createLoginHistory(newLoginHistory);
@@ -76,10 +79,11 @@ export class AuthService {
    * @param userId
    * @returns boolean
    */
-  public async logout(userId: number): Promise<boolean> {
+  public async logout(userId: number, deviceId: string): Promise<boolean> {
     const newLogoutHistory = new UserLoginHistory({
       userId: userId,
       actionType: USER_LOGIN.LOGOUT,
+      deviceId: deviceId,
     });
     await this.userLoginHistoryRepository.createLoginHistory(newLogoutHistory);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1170,6 +1170,11 @@
   dependencies:
     "@types/superagent" "*"
 
+"@types/useragent@^2.3.4":
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/@types/useragent/-/useragent-2.3.4.tgz#689c6c85cfe7200c467d02ae9182c15ea182fa6e"
+  integrity sha512-4pGiUe4NptP06CwsW+pY/3bgGCUdMf8+DrtyJ+jNR1UTPnSEA57TsskdBtE+oq+GpPCXIR+n51RvzKIsyy4rrw==
+
 "@types/validator@^13.7.10":
   version "13.7.15"
   resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.7.15.tgz#408c99d1b5f0eecc78109c11f896f72d1f026a10"
@@ -3931,6 +3936,14 @@ long@^5.2.1:
   resolved "https://registry.yarnpkg.com/long/-/long-5.2.3.tgz#a3ba97f3877cf1d778eccbcb048525ebb77499e1"
   integrity sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q==
 
+lru-cache@4.1.x:
+  version "4.1.5"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
+  integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
+  dependencies:
+    pseudomap "^1.0.2"
+    yallist "^2.1.2"
+
 lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
@@ -4586,6 +4599,11 @@ proxy-addr@~2.0.7:
   dependencies:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
+
+pseudomap@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
+  integrity sha512-b/YwNhb8lk1Zz2+bXXpS/LK9OisiZZ1SNsSLxN1x2OXVEhW2Ckr/7mWE5vrC1ZTiJlD9g19jWszTmJsB+oEpFQ==
 
 pump@^3.0.0:
   version "3.0.0"
@@ -5247,7 +5265,7 @@ through@^2.3.6:
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==
 
-tmp@^0.0.33:
+tmp@0.0.x, tmp@^0.0.33:
   version "0.0.33"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.33.tgz#6d34335889768d21b2bcda0aa277ced3b1bfadf9"
   integrity sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==
@@ -5481,6 +5499,14 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+useragent@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/useragent/-/useragent-2.3.0.tgz#217f943ad540cb2128658ab23fc960f6a88c9972"
+  integrity sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==
+  dependencies:
+    lru-cache "4.1.x"
+    tmp "0.0.x"
+
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -5679,6 +5705,11 @@ y18n@^5.0.5:
   version "5.0.8"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-5.0.8.tgz#7f4934d0f7ca8c56f95314939ddcd2dd91ce1d55"
   integrity sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==
+
+yallist@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+  integrity sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==
 
 yallist@^3.0.2:
   version "3.1.1"


### PR DESCRIPTION
## 🐳 개요
로그인 & 로그아웃시 디바이스 ID 로직 추가 
close #37 

## 🐳 작업사항
- 로그인 & 로그아웃시 device Id 저장하는 로직 추가
   - useragent 정보를 쉽게 가져올수 있는 라이브러리 추가
   - divice.family 속성을 통해 기기 정보를 가져옴 => 단, PC로 접속시 other로만 표시되 DESKTOP 으로 변경
   - ID 값을 어떤정보 저장할지에 따라, 추후 로직 변경 필요
  

