### PR TITLE
refactor: 차단 유저에 따른 피드 및 유저 조회 리팩토링

### DIFF
--- a/src/modules/comment-reply/comment-reply.repository.ts
+++ b/src/modules/comment-reply/comment-reply.repository.ts
@@ -154,7 +154,7 @@ export class CommentReplyRepository {
    */
   async deleteComemntReply(commentId: number, replyId: number) {
     await dataSource.transaction(async (transaction) => {
-      await dataSource
+      await transaction
         .createQueryBuilder()
         .delete()
         .from(CommentReply)

--- a/src/modules/comment/comment.repository.ts
+++ b/src/modules/comment/comment.repository.ts
@@ -152,7 +152,7 @@ export class CommentRepository {
    */
   async deleteComemnt(feedId: number, commentId: number) {
     await dataSource.transaction(async (transaction) => {
-      await dataSource
+      await transaction
         .createQueryBuilder()
         .delete()
         .from(Comment)

--- a/src/modules/feed/feed.controller.ts
+++ b/src/modules/feed/feed.controller.ts
@@ -45,18 +45,6 @@ export class FeedController {
     );
   }
 
-  @Get('/feed/tag')
-  @HttpCode(HttpStatus.OK)
-  @UseGuards(new UserGuard())
-  public async findAllByTag(
-    @UserInfo() user: User,
-    @Query() feedListDto: FeedListDto,
-  ): Promise<BaseResponseVo<PaginateResponseVo<FeedFindOneVo>>> {
-    return new BaseResponseVo<PaginateResponseVo<FeedFindOneVo>>(
-      await this.feedService.findAllByTag(user, feedListDto),
-    );
-  }
-
   @Get('/feed/following')
   @HttpCode(HttpStatus.OK)
   @UseGuards(new UserGuard())

--- a/src/modules/feed/feed.module.ts
+++ b/src/modules/feed/feed.module.ts
@@ -6,10 +6,13 @@ import { FeedService } from './feed.service';
 import { FeedController } from './feed.controller';
 import { UserModule } from '../user/user.module';
 import { userProviders } from '../user/user.provider';
-import { UserBlockModule } from '../user-block/user-block.module';
+// import { UserBlockModule } from '../user-block/user-block.module';
 import { FeedLikeModule } from '../feed-like/feed-like.module';
 import { TagModule } from '../tag/tag.module';
 import { tagProviders } from '../tag/tag.provider';
+import { userBlockProviders } from '../user-block/user-block.provider';
+import { UserBlockRepository } from '../user-block/user-block.repository';
+import { UserBlockModule } from '../user-block/user-block.module';
 
 @Module({
   imports: [
@@ -22,6 +25,7 @@ import { tagProviders } from '../tag/tag.provider';
   controllers: [FeedController],
   providers: [
     ...userProviders,
+    ...userBlockProviders,
     ...feedProviders,
     ...tagProviders,
     FeedRepository,

--- a/src/modules/feed/feed.repository.ts
+++ b/src/modules/feed/feed.repository.ts
@@ -358,7 +358,7 @@ export class FeedRepository {
 
       // * 태그가 존재 하지 않는 경우
       if (feedUpdateDto.tagNames.length === 0) {
-        await dataSource
+        await transaction
           .createQueryBuilder()
           .delete()
           .from(MapperFeedTag)
@@ -420,7 +420,7 @@ export class FeedRepository {
                   });
 
                   if (deleteTag && deleteTag.id) {
-                    await dataSource
+                    await transaction
                       .createQueryBuilder()
                       .delete()
                       .from(MapperFeedTag)
@@ -539,7 +539,7 @@ export class FeedRepository {
   public async hardDeleteFeed(userId: number, feedId: number) {
     await dataSource.transaction(async (transaction) => {
       // * FEED IMAGE 삭제
-      await dataSource
+      await transaction
         .createQueryBuilder()
         .delete()
         .from(FeedImage)
@@ -547,7 +547,7 @@ export class FeedRepository {
         .execute();
 
       // * FEED LIKE 삭제
-      await dataSource
+      await transaction
         .createQueryBuilder()
         .delete()
         .from(FeedLike)
@@ -557,7 +557,7 @@ export class FeedRepository {
         .execute();
 
       // * FEED BOOKMARK 삭제
-      await dataSource
+      await transaction
         .createQueryBuilder()
         .delete()
         .from(FeedBookmark)
@@ -567,7 +567,7 @@ export class FeedRepository {
         .execute();
 
       // * FEED 삭제
-      await dataSource
+      await transaction
         .createQueryBuilder()
         .delete()
         .from(Feed)
@@ -591,7 +591,7 @@ export class FeedRepository {
    */
   public async deleteFeedImage(feedId: number, sortOrder: number) {
     await dataSource.transaction(async (transaction) => {
-      await dataSource
+      await transaction
         .createQueryBuilder()
         .delete()
         .from(FeedImage)
@@ -608,7 +608,7 @@ export class FeedRepository {
    */
   public async deleteLikeFeed(userId: number, feedId: number) {
     await dataSource.transaction(async (transaction) => {
-      await dataSource
+      await transaction
         .createQueryBuilder()
         .delete()
         .from(FeedLike)
@@ -628,13 +628,15 @@ export class FeedRepository {
    * @param feedId
    */
   public async deleteBookmarkFeed(userId: number, feedId: number) {
-    await dataSource
-      .createQueryBuilder()
-      .delete()
-      .from(FeedBookmark)
-      .where('feedId = :feedId', { feedId: feedId })
-      .andWhere('userId = :userId', { userId: userId })
-      .execute();
+    await dataSource.transaction(async (transaction) => {
+      await transaction
+        .createQueryBuilder()
+        .delete()
+        .from(FeedBookmark)
+        .where('feedId = :feedId', { feedId: feedId })
+        .andWhere('userId = :userId', { userId: userId })
+        .execute();
+    });
   }
 
   private async processFeedItem(

--- a/src/modules/feed/feed.service.ts
+++ b/src/modules/feed/feed.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { FeedRepository } from './feed.repository';
 import { FeedFindOneVo } from './vo';
 import { UserRepository } from '../user/user.repository';
@@ -33,16 +33,17 @@ export class FeedService {
     const blockerUsers = await this.userBlockRepository.findAllByBlockerIds(
       feedListDto.viewerId,
     );
-    const blockedUsers = await this.userBlockRepository.findAllByBlockedIds(
+    const blockedMeUsers = await this.userBlockRepository.findAllByBlockedIds(
       feedListDto.viewerId,
     );
-    const excludeUserIds = [...blockerUsers, ...blockedUsers];
+    const excludeUserIds = [...blockerUsers, ...blockedMeUsers];
 
     const feeds = await this.feedRepository.findAll(
       user,
       feedListDto,
       excludeUserIds,
     );
+
     if (!feeds) throw new NotFoundException();
 
     return feeds;

--- a/src/modules/feed/feed.service.ts
+++ b/src/modules/feed/feed.service.ts
@@ -29,17 +29,22 @@ export class FeedService {
     user: User,
     feedListDto?: FeedListDto,
   ): Promise<PaginateResponseVo<FeedFindOneVo>> {
-    const feeds = await this.feedRepository.findAll(user, feedListDto);
-    if (!feeds) throw new NotFoundException();
-    return feeds;
-  }
+    // * 차단한 유저 혹은 나를 차단한 유저의 피드 검색 제외
+    const blockerUsers = await this.userBlockRepository.findAllByBlockerIds(
+      feedListDto.viewerId,
+    );
+    const blockedUsers = await this.userBlockRepository.findAllByBlockedIds(
+      feedListDto.viewerId,
+    );
+    const excludeUserIds = [...blockerUsers, ...blockedUsers];
 
-  public async findAllByTag(
-    user: User,
-    feedListDto?: FeedListDto,
-  ): Promise<PaginateResponseVo<FeedFindOneVo>> {
-    const feeds = await this.feedRepository.findAllByTag(user, feedListDto);
+    const feeds = await this.feedRepository.findAll(
+      user,
+      feedListDto,
+      excludeUserIds,
+    );
     if (!feeds) throw new NotFoundException();
+
     return feeds;
   }
 

--- a/src/modules/mapper-user-follow/mapper-user-follow.controller.ts
+++ b/src/modules/mapper-user-follow/mapper-user-follow.controller.ts
@@ -21,6 +21,8 @@ import { MapperUserFollow } from './mapper-user-follow.entity';
 import { BaseResponseVo, PaginateResponseVo, UserGuard } from 'src/core';
 import { FollowFindOneVo } from './vo';
 import { UserFindOneVo } from '../user/vo';
+import { UserInfo } from 'src/common';
+import { User } from '../user/user.entity';
 
 @Controller()
 @ApiTags('MPPAER USER FOLLOW')
@@ -33,11 +35,13 @@ export class MapperUserFollowController {
   @Get('/user/:username/followings')
   @HttpCode(HttpStatus.OK)
   async findAllFollowings(
+    @UserInfo() user: User,
     @Param('username') username: string,
     @Query() mapperUserfollowListDto: MapperUserFollowListDto,
   ): Promise<BaseResponseVo<PaginateResponseVo<UserFindOneVo>>> {
     return new BaseResponseVo<PaginateResponseVo<UserFindOneVo>>(
       await this.mapperUserFollowService.findAllByFollowings(
+        user,
         username,
         mapperUserfollowListDto,
       ),
@@ -47,11 +51,13 @@ export class MapperUserFollowController {
   @Get('/user/:username/followers')
   @HttpCode(HttpStatus.OK)
   async findAllFollowers(
+    @UserInfo() user: User,
     @Param('username') username: string,
     @Query() mapperUserfollowListDto: MapperUserFollowListDto,
   ): Promise<BaseResponseVo<PaginateResponseVo<FollowFindOneVo>>> {
     return new BaseResponseVo<PaginateResponseVo<FollowFindOneVo>>(
       await this.mapperUserFollowService.findAllByFollowers(
+        user,
         username,
         mapperUserfollowListDto,
       ),

--- a/src/modules/mapper-user-follow/mapper-user-follow.module.ts
+++ b/src/modules/mapper-user-follow/mapper-user-follow.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { DatabaseModule } from 'src/config';
 import { MapperUserFollowRepository } from './mapper-user-follow.repository';
 import { MapperUserFollowController } from './mapper-user-follow.controller';
@@ -6,9 +6,14 @@ import { MapperUserFollowService } from './mapper-user-follow.service';
 import { mapperUserFollowProviders } from './mapper-user-follow.provider';
 import { UserModule } from '../user/user.module';
 import { userProviders } from '../user/user.provider';
+import { UserBlockModule } from '../user-block/user-block.module';
 
 @Module({
-  imports: [DatabaseModule, UserModule],
+  imports: [
+    DatabaseModule,
+    forwardRef(() => UserModule),
+    forwardRef(() => UserBlockModule),
+  ],
   controllers: [MapperUserFollowController],
   providers: [
     ...userProviders,

--- a/src/modules/mapper-user-follow/mapper-user-follow.repository.ts
+++ b/src/modules/mapper-user-follow/mapper-user-follow.repository.ts
@@ -10,7 +10,6 @@ import { MapperUserFollow } from './mapper-user-follow.entity';
 import { User } from '../user/user.entity';
 import { PaginateResponseVo } from 'src/core';
 import { YN } from 'src/common';
-import { FollowFindOneVo } from './vo';
 import { UserFindOneVo } from '../user/vo';
 
 @Injectable()
@@ -30,16 +29,18 @@ export class MapperUserFollowRepository {
    * @returns
    */
   async findAllByFollowings(
-    userId: number,
+    userId: number, // 본인 아이디
+    followId: number,
     mapperUserfollowListDto: MapperUserFollowListDto,
+    excludeUserIds?: number[],
   ): Promise<PaginateResponseVo<UserFindOneVo>> {
     const page = mapperUserfollowListDto.page;
     const limit = mapperUserfollowListDto.limit;
     const offset = (page - 1) * limit;
 
-    const user = this.mapperUserFollowRepository
+    const users = this.mapperUserFollowRepository
       .createQueryBuilder('mapper')
-      .leftJoinAndSelect('mapper.following', 'user')
+      .innerJoinAndSelect('mapper.following', 'user')
       .where(
         new Brackets((qb) => {
           qb.where('user.username LIKE :query OR user.nickname LIKE :query', {
@@ -47,19 +48,35 @@ export class MapperUserFollowRepository {
           });
         }),
       )
-      .andWhere('mapper.userId = :userId', {
-        userId: userId,
-      })
       .andWhere('user.delYn = :delYn', { delYn: YN.N })
+      .andWhere('mapper.userId = :userId', {
+        userId: followId,
+      });
+
+    if (excludeUserIds.length > 0) {
+      users.andWhere('mapper.userId NOT IN (:...userId)', {
+        userId: [excludeUserIds],
+      });
+    }
+
+    users
       .orderBy('mapper.createdAt', mapperUserfollowListDto.orderBy)
       .offset(offset)
       .limit(limit);
 
-    const [items, totalCount] = await user.getManyAndCount();
+    const [items, totalCount] = await users.getManyAndCount();
     const lasPage = Math.ceil(totalCount / limit);
 
+    const sortedItems = items.map((item) => item.following);
+
+    // 본인 정보 가장 상단 노출
+    const findIndex = sortedItems.findIndex((user) => user.id === userId);
+    if (findIndex !== -1) {
+      sortedItems.unshift(...sortedItems.splice(findIndex, 1));
+    }
+
     return {
-      items: items.map((item) => item.following),
+      items: sortedItems,
       totalCount: totalCount,
       pageInfo: {
         page,
@@ -89,15 +106,17 @@ export class MapperUserFollowRepository {
    */
   async findAllByFollowers(
     userId: number,
+    followId: number,
     mapperUserfollowListDto: MapperUserFollowListDto,
+    excludeUserIds?: number[],
   ): Promise<PaginateResponseVo<UserFindOneVo>> {
     const page = mapperUserfollowListDto.page;
     const limit = mapperUserfollowListDto.limit;
     const offset = (page - 1) * limit;
 
-    const user = this.mapperUserFollowRepository
+    const users = this.mapperUserFollowRepository
       .createQueryBuilder('mapper')
-      .leftJoinAndSelect('mapper.follower', 'user')
+      .innerJoinAndSelect('mapper.follower', 'user')
       .where(
         new Brackets((qb) => {
           qb.where('user.username LIKE :query OR user.nickname LIKE :query', {
@@ -105,19 +124,35 @@ export class MapperUserFollowRepository {
           });
         }),
       )
-      .andWhere('mapper.followingId = :followingId', {
-        followingId: userId,
-      })
       .andWhere('user.delYn = :delYn', { delYn: YN.N })
+      .andWhere('mapper.followingId = :followingId', {
+        followingId: followId,
+      });
+
+    if (excludeUserIds.length > 0) {
+      users.andWhere('mapper.userId NOT IN (:...userId)', {
+        userId: [...excludeUserIds],
+      });
+    }
+
+    users
       .orderBy('mapper.createdAt', mapperUserfollowListDto.orderBy)
       .offset(offset)
       .limit(limit);
 
-    const [items, totalCount] = await user.getManyAndCount();
+    const [items, totalCount] = await users.getManyAndCount();
     const lasPage = Math.ceil(totalCount / limit);
 
+    const sortedItems = items.map((item) => item.follower);
+
+    // 본인 정보 가장 상단 노출
+    const findIndex = sortedItems.findIndex((user) => user.id === userId);
+    if (findIndex !== -1) {
+      sortedItems.unshift(...sortedItems.splice(findIndex, 1));
+    }
+
     return {
-      items: items.map((item) => item.follower),
+      items: sortedItems,
       totalCount: totalCount,
       pageInfo: {
         page,

--- a/src/modules/mapper-user-follow/mapper-user-follow.repository.ts
+++ b/src/modules/mapper-user-follow/mapper-user-follow.repository.ts
@@ -172,7 +172,7 @@ export class MapperUserFollowRepository {
     mapperUserFollowDeleteDto: MapperUserFollowDeleteDto,
   ) {
     await dataSource.transaction(async (transaction) => {
-      await dataSource
+      await transaction
         .createQueryBuilder()
         .delete()
         .from(MapperUserFollow)

--- a/src/modules/mapper-user-follow/mapper-user-follow.service.ts
+++ b/src/modules/mapper-user-follow/mapper-user-follow.service.ts
@@ -8,37 +8,67 @@ import {
 import { UserRepository } from '../user/user.repository';
 import { MapperUserFollow } from './mapper-user-follow.entity';
 import { PaginateResponseVo } from 'src/core';
-import { FollowFindOneVo } from './vo';
 import { UserFindOneVo } from '../user/vo';
+import { UserBlockRepository } from '../user-block/user-block.repository';
+import { User } from '../user/user.entity';
 
 @Injectable()
 export class MapperUserFollowService {
   constructor(
     private readonly mapperUserFollowRepository: MapperUserFollowRepository,
     private readonly userRepository: UserRepository,
+    private readonly userBlockRepository: UserBlockRepository,
   ) {}
 
   async findAllByFollowings(
+    user: User,
     username: string,
     mapperUserfollowListDto: MapperUserFollowListDto,
   ): Promise<PaginateResponseVo<UserFindOneVo>> {
-    const user = await this.userRepository.findUserByUsername(username);
-    if (!user) throw new NotFoundException('존재하지 않는 사용자 입니다');
+    const profileUser = await this.userRepository.findUserByUsername(username);
+
+    // * 차단한 유저 혹은 나를 차단한 유저 검색 제외
+    const blockerUsers = await this.userBlockRepository.findAllByBlockerIds(
+      user.id,
+    );
+    const blockedMeUsers = await this.userBlockRepository.findAllByBlockedIds(
+      user.id,
+    );
+    const excludeUserIds = [...blockerUsers, ...blockedMeUsers];
+
+    if (!profileUser)
+      throw new NotFoundException('존재하지 않는 사용자 입니다');
     return await this.mapperUserFollowRepository.findAllByFollowings(
       user.id,
+      profileUser.id,
       mapperUserfollowListDto,
+      excludeUserIds,
     );
   }
 
   async findAllByFollowers(
+    user: User,
     username: string,
     mapperUserfollowListDto: MapperUserFollowListDto,
   ): Promise<PaginateResponseVo<UserFindOneVo>> {
-    const user = await this.userRepository.findUserByUsername(username);
-    if (!user) throw new NotFoundException('존재하지 않는 사용자 입니다');
+    const profileUser = await this.userRepository.findUserByUsername(username);
+    if (!profileUser)
+      throw new NotFoundException('존재하지 않는 사용자 입니다');
+
+    // * 차단한 유저 혹은 나를 차단한 유저 검색 제외
+    const blockerUsers = await this.userBlockRepository.findAllByBlockerIds(
+      user.id,
+    );
+    const blockedMeUsers = await this.userBlockRepository.findAllByBlockedIds(
+      user.id,
+    );
+    const excludeUserIds = [...blockerUsers, ...blockedMeUsers];
+
     return await this.mapperUserFollowRepository.findAllByFollowers(
       user.id,
+      profileUser.id,
       mapperUserfollowListDto,
+      excludeUserIds,
     );
   }
 

--- a/src/modules/mapper-user-follow/mapper-user-follow.service.ts
+++ b/src/modules/mapper-user-follow/mapper-user-follow.service.ts
@@ -27,11 +27,14 @@ export class MapperUserFollowService {
   ): Promise<PaginateResponseVo<UserFindOneVo>> {
     const profileUser = await this.userRepository.findUserByUsername(username);
 
-    // *  나를 차단한 유저 검색 제외
+    // * 차단한 유저 혹은 나를 차단한 유저 검색 제외
+    const blockerUsers = await this.userBlockRepository.findAllByBlockerIds(
+      user.id,
+    );
     const blockedMeUsers = await this.userBlockRepository.findAllByBlockedIds(
       user.id,
     );
-    const excludeUserIds = [...blockedMeUsers];
+    const excludeUserIds = [...blockerUsers, ...blockedMeUsers];
 
     if (!profileUser)
       throw new NotFoundException('존재하지 않는 사용자 입니다');
@@ -52,11 +55,14 @@ export class MapperUserFollowService {
     if (!profileUser)
       throw new NotFoundException('존재하지 않는 사용자 입니다');
 
-    // *  나를 차단한 유저 검색 제외
+    // * 차단한 유저 혹은 나를 차단한 유저 검색 제외
+    const blockerUsers = await this.userBlockRepository.findAllByBlockerIds(
+      user.id,
+    );
     const blockedMeUsers = await this.userBlockRepository.findAllByBlockedIds(
       user.id,
     );
-    const excludeUserIds = [...blockedMeUsers];
+    const excludeUserIds = [...blockerUsers, ...blockedMeUsers];
 
     return await this.mapperUserFollowRepository.findAllByFollowers(
       user.id,

--- a/src/modules/mapper-user-follow/mapper-user-follow.service.ts
+++ b/src/modules/mapper-user-follow/mapper-user-follow.service.ts
@@ -27,14 +27,11 @@ export class MapperUserFollowService {
   ): Promise<PaginateResponseVo<UserFindOneVo>> {
     const profileUser = await this.userRepository.findUserByUsername(username);
 
-    // * 차단한 유저 혹은 나를 차단한 유저 검색 제외
-    const blockerUsers = await this.userBlockRepository.findAllByBlockerIds(
-      user.id,
-    );
+    // *  나를 차단한 유저 검색 제외
     const blockedMeUsers = await this.userBlockRepository.findAllByBlockedIds(
       user.id,
     );
-    const excludeUserIds = [...blockerUsers, ...blockedMeUsers];
+    const excludeUserIds = [...blockedMeUsers];
 
     if (!profileUser)
       throw new NotFoundException('존재하지 않는 사용자 입니다');
@@ -55,14 +52,11 @@ export class MapperUserFollowService {
     if (!profileUser)
       throw new NotFoundException('존재하지 않는 사용자 입니다');
 
-    // * 차단한 유저 혹은 나를 차단한 유저 검색 제외
-    const blockerUsers = await this.userBlockRepository.findAllByBlockerIds(
-      user.id,
-    );
+    // *  나를 차단한 유저 검색 제외
     const blockedMeUsers = await this.userBlockRepository.findAllByBlockedIds(
       user.id,
     );
-    const excludeUserIds = [...blockerUsers, ...blockedMeUsers];
+    const excludeUserIds = [...blockedMeUsers];
 
     return await this.mapperUserFollowRepository.findAllByFollowers(
       user.id,

--- a/src/modules/user-block/user-block.controller.ts
+++ b/src/modules/user-block/user-block.controller.ts
@@ -17,6 +17,7 @@ import { BaseResponseVo, PaginateResponseVo, UserGuard } from 'src/core';
 import { UserInfo } from 'src/common';
 import { User } from '../user/user.entity';
 import { UserBlock } from './user-block.entity';
+import { UserFindOneVo } from '../user/vo';
 
 @Controller('user-block')
 @ApiTags('USER BLOCK')
@@ -37,8 +38,12 @@ export class UserBlockController {
 
   @Post()
   @HttpCode(HttpStatus.CREATED)
-  async createUserBlock(@Body() UserBlockCreateDto: UserBlockCreateDto) {
-    return await this.userBlockService.createUserBlock(UserBlockCreateDto);
+  async createUserBlock(
+    @Body() UserBlockCreateDto: UserBlockCreateDto,
+  ): Promise<BaseResponseVo<UserFindOneVo>> {
+    return new BaseResponseVo<UserFindOneVo>(
+      await this.userBlockService.createUserBlock(UserBlockCreateDto),
+    );
   }
 
   @Delete()

--- a/src/modules/user-block/user-block.module.ts
+++ b/src/modules/user-block/user-block.module.ts
@@ -1,16 +1,28 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { userBlockProviders } from './user-block.provider';
 import { UserBlockRepository } from './user-block.repository';
 import { DatabaseModule } from 'src/config';
 import { UserBlockService } from './user-block.service';
 import { UserBlockController } from './user-block.controller';
 import { UserModule } from '../user/user.module';
+import { mapperUserFollowProviders } from '../mapper-user-follow/mapper-user-follow.provider';
+import { userProviders } from '../user/user.provider';
 import { MapperUserFollowModule } from '../mapper-user-follow/mapper-user-follow.module';
 
 @Module({
-  imports: [DatabaseModule, UserModule, MapperUserFollowModule],
+  imports: [
+    DatabaseModule,
+    forwardRef(() => UserModule),
+    forwardRef(() => MapperUserFollowModule),
+  ],
   controllers: [UserBlockController],
-  providers: [...userBlockProviders, UserBlockRepository, UserBlockService],
+  providers: [
+    ...userProviders,
+    ...userBlockProviders,
+    ...mapperUserFollowProviders,
+    UserBlockRepository,
+    UserBlockService,
+  ],
   exports: [UserBlockModule, UserBlockRepository, UserBlockService],
 })
 export class UserBlockModule {}

--- a/src/modules/user-block/user-block.repository.ts
+++ b/src/modules/user-block/user-block.repository.ts
@@ -101,7 +101,7 @@ export class UserBlockRepository {
    */
   public async deleteUserBlock(userBlockCreateDto: UserBlockCreateDto) {
     await dataSource.transaction(async (transaction) => {
-      await dataSource
+      await transaction
         .createQueryBuilder()
         .delete()
         .from(UserBlock)

--- a/src/modules/user-block/user-block.repository.ts
+++ b/src/modules/user-block/user-block.repository.ts
@@ -33,6 +33,9 @@ export class UserBlockRepository {
       .createQueryBuilder('user')
       .innerJoinAndSelect('user.blockedUser', 'blockedUser')
       .where('user.userId = :userId', { userId: userId })
+      .andWhere('user.actionType = :actionType', {
+        actionType: USER_BLOCK.BLOCKER,
+      })
       .orderBy('user.createdAt', ORDER_BY_VALUE.DESC)
       .offset(offset)
       .limit(limit);

--- a/src/modules/user-block/user-block.repository.ts
+++ b/src/modules/user-block/user-block.repository.ts
@@ -52,7 +52,7 @@ export class UserBlockRepository {
   }
 
   /**
-   * 나를 차단한 유저 ID 배열
+   * 내가 차단한 유저 ID 배열
    * @param userId
    * @returns
    */

--- a/src/modules/user-block/user-block.repository.ts
+++ b/src/modules/user-block/user-block.repository.ts
@@ -4,7 +4,7 @@ import { UserBlock } from './user-block.entity';
 import { Repository } from 'typeorm';
 import { PaginateResponseVo } from 'src/core';
 import { UserBlockCreateDto, UserBlockListDto } from './dto';
-import { ORDER_BY_VALUE } from 'src/common';
+import { ORDER_BY_VALUE, USER_BLOCK } from 'src/common';
 
 @Injectable()
 export class UserBlockRepository {
@@ -14,7 +14,13 @@ export class UserBlockRepository {
   ) {}
 
   // SELECTS
-  // * 내가 차단한 유저
+
+  /**
+   * 내가 차단한 유저 목록
+   * @param userId
+   * @param userBlockListDto
+   * @returns
+   */
   public async findAll(
     userId: number,
     userBlockListDto: UserBlockListDto,
@@ -43,6 +49,46 @@ export class UserBlockRepository {
         isLast: page === lasPage ? true : false,
       },
     };
+  }
+
+  /**
+   * 나를 차단한 유저 ID 배열
+   * @param userId
+   * @returns
+   */
+  public async findAllByBlockerIds(userId: number): Promise<number[]> {
+    const users = await UserBlock.createQueryBuilder('userBlock')
+      .where('userBlock.userId = :userId', {
+        userId,
+      })
+      .andWhere('userBlock.actionType = :actionType', {
+        actionType: USER_BLOCK.BLOCKER,
+      })
+      .getMany();
+
+    const userIds = users.map((user) => user.blockedUserId);
+
+    return userIds;
+  }
+
+  /**
+   * 나를 차단한 유저 ID 배열
+   * @param userId
+   * @returns
+   */
+  public async findAllByBlockedIds(userId: number): Promise<number[]> {
+    const users = await UserBlock.createQueryBuilder('userBlock')
+      .where('userBlock.userId = :userId', {
+        userId,
+      })
+      .andWhere('userBlock.actionType = :actionType', {
+        actionType: USER_BLOCK.BLOCKED,
+      })
+      .getMany();
+
+    const userIds = users.map((user) => user.blockedUserId);
+
+    return userIds;
   }
 
   public async findOne(

--- a/src/modules/user-block/user-block.repository.ts
+++ b/src/modules/user-block/user-block.repository.ts
@@ -4,6 +4,7 @@ import { UserBlock } from './user-block.entity';
 import { Repository } from 'typeorm';
 import { PaginateResponseVo } from 'src/core';
 import { UserBlockCreateDto, UserBlockListDto } from './dto';
+import { ORDER_BY_VALUE } from 'src/common';
 
 @Injectable()
 export class UserBlockRepository {
@@ -13,6 +14,7 @@ export class UserBlockRepository {
   ) {}
 
   // SELECTS
+  // * 내가 차단한 유저
   public async findAll(
     userId: number,
     userBlockListDto: UserBlockListDto,
@@ -23,9 +25,9 @@ export class UserBlockRepository {
 
     const blockUsers = this.userBlockRepository
       .createQueryBuilder('user')
-      .leftJoinAndSelect('user.blockedUser', 'blockedUser')
+      .innerJoinAndSelect('user.blockedUser', 'blockedUser')
       .where('user.userId = :userId', { userId: userId })
-      .orderBy('user.createdAt', 'DESC')
+      .orderBy('user.createdAt', ORDER_BY_VALUE.DESC)
       .offset(offset)
       .limit(limit);
 

--- a/src/modules/user-block/user-block.service.ts
+++ b/src/modules/user-block/user-block.service.ts
@@ -4,6 +4,7 @@ import { UserBlockRepository } from './user-block.repository';
 import { UserRepository } from '../user/user.repository';
 import { MapperUserFollowRepository } from '../mapper-user-follow/mapper-user-follow.repository';
 import { MapperUserFollowDeleteDto } from '../mapper-user-follow/dto';
+import { USER_BLOCK } from 'src/common';
 
 @Injectable()
 export class UserBlockService {
@@ -62,7 +63,21 @@ export class UserBlockService {
       );
     }
 
-    await this.userBlockRepository.createUserBlock(userBlockCreateDto);
+    const blockerUser = new UserBlockCreateDto({
+      userId: userBlockCreateDto.userId,
+      blockedUserId: userBlockCreateDto.blockedUserId,
+      actionType: USER_BLOCK.BLOCKER,
+    });
+
+    await this.userBlockRepository.createUserBlock(blockerUser);
+
+    const blockedUser = new UserBlockCreateDto({
+      userId: userBlockCreateDto.blockedUserId,
+      blockedUserId: userBlockCreateDto.userId,
+      actionType: USER_BLOCK.BLOCKED,
+    });
+
+    await this.userBlockRepository.createUserBlock(blockedUser);
   }
 
   /**

--- a/src/modules/user/user.module.ts
+++ b/src/modules/user/user.module.ts
@@ -5,11 +5,20 @@ import { DatabaseModule } from 'src/config/database/database.module';
 import { UserService } from './user.service';
 import { UserController } from './user.controller';
 import { HashService } from '../auth/hash.service';
+import { userBlockProviders } from '../user-block/user-block.provider';
+import { UserBlockModule } from '../user-block/user-block.module';
+import { MapperUserFollowModule } from '../mapper-user-follow/mapper-user-follow.module';
 
 @Module({
-  imports: [DatabaseModule],
+  imports: [DatabaseModule, UserBlockModule, MapperUserFollowModule],
   controllers: [UserController],
-  providers: [...userProviders, UserRepository, UserService, HashService],
+  providers: [
+    ...userProviders,
+    ...userBlockProviders,
+    UserRepository,
+    UserService,
+    HashService,
+  ],
   exports: [UserModule, UserRepository, UserService],
 })
 export class UserModule {}

--- a/src/modules/user/user.service.ts
+++ b/src/modules/user/user.service.ts
@@ -13,10 +13,14 @@ import {
 } from './dto';
 import { UserDeleteDto } from './dto/user-delete.dto';
 import { PaginateResponseVo } from 'src/core';
+import { UserBlockRepository } from '../user-block/user-block.repository';
 
 @Injectable()
 export class UserService {
-  constructor(private readonly userRepository: UserRepository) {}
+  constructor(
+    private readonly userRepository: UserRepository,
+    private readonly userBlockRepository: UserBlockRepository,
+  ) {}
 
   // GET SERVICES
 
@@ -28,7 +32,11 @@ export class UserService {
   public async findAll(
     userListDto?: UserListDto,
   ): Promise<PaginateResponseVo<UserFindOneVo>> {
-    return await this.userRepository.findAll(userListDto);
+    // * 나를 차단한 유저 검색 제외
+    const blockedMeUsers = await this.userBlockRepository.findAllByBlockedIds(
+      userListDto.viewerId,
+    );
+    return await this.userRepository.findAll(userListDto, blockedMeUsers);
   }
 
   /**


### PR DESCRIPTION
## 🐳 개요
차단 유저에 따른 피드 및 유저 조회 리팩토링

## 🐳 작업사항
|    |  내가 차단한 유저 |  나를 차단한 유저  |
| --- |  --- | --- |
| 전체 유저 조회  | O |  X |
| 팔로잉 유저 조회 | X  |  X |
| 팔로워 유저 조회  | X  |  X |
| 전체 피드 조회  | X  |  X |
| 태그별 피드 조회  | X  |  X |

- 전체 유저 검색
  -  **내가 차단한** 유저는 검색 O 
  -  **나를 차단한** 유저는 검색 X (목록 제외)
- 팔로잉&팔로워 유저
  -   나를 차단한 유저 / 내가 차단한 유저 모두 검색 X (목록 제외) 
  -   팔로워 & 팔로잉 목록에 내 정보가 있을 경우 **가장 상단**에 노출되도록 처리 
- 전체 피드 & 태그별 피드 
  -  나를 차단한 유저 / 내가 차단한 유저 모두 검색 X (목록 제외)  
  - `feedListDto` 에서 `tagName`을 optional 로 받기때문에 별도의 컨트롤러 필요 없었음 

## 🐳 공유사항
- 팔로워&팔로잉 유저 목록과 프로필상의 count를 동기화 시킬지 고민 (유저 정보의 count 필드에서 가져오기때문)
   - 실제 인스타그램은 동기화 X