### PR TITLE
fix: 페이지네이션 처리되는 유저 목록에서 본인 상단 노출 orderBy 조건으로 리팩토링

### DIFF
--- a/src/modules/user/user.repository.ts
+++ b/src/modules/user/user.repository.ts
@@ -59,18 +59,15 @@ export class UserRepository {
       });
     }
 
-    users.orderBy('user.createdAt', ORDER_BY_VALUE.ASC).Paginate(userListDto);
+    users
+      .orderBy(
+        'CASE WHEN user.id = :userId THEN 0 ELSE 1 END',
+        ORDER_BY_VALUE.ASC,
+      )
+      .setParameter('userId', Number(userListDto.viewerId))
+      .Paginate(userListDto);
 
     const [items, totalCount] = await users.getManyAndCount();
-
-    // 본인 정보 가장 상단 노출
-    const findIndex = items.findIndex(
-      (user) => user.id === Number(userListDto.viewerId),
-    );
-
-    if (findIndex !== -1) {
-      items.unshift(...items.splice(findIndex, 1));
-    }
 
     return generatePaginatedResponse(
       items,


### PR DESCRIPTION
## 🐳 개요
페이지네이션 처리되는 유저 목록에서 본인 상단 노출 orderBy 조건으로 리팩토링

## 🐳 작업사항
### 오류 발견
- 기존에 유저 목록에서 본인 정보를 가장 상단에 노출하는 것을 id값을 `index` 로 찾아 `unshift` 하는 형식으로 처리
  - 해당 로직의 경우 이미 getManyAndCount로 페이징 처리되었기때문에 
     찾는 id의 값이 두번째 배열 이후에 존재할 경우 제대로 된 index 정보를 찾을 수 없음 
  - 예를 들면 limit(take) 가 10일 경우 14번째에 있는 유저는 2페이지에 속해 되어버리기때문에, 
    첫번째 배열에서는 존재하지 않게 되어 찾을 수 없고,  두번째 배열 내 기준에서 index를 찾게 되는 것이다
 -  1페이지 배열 내  unshift 되지 않기때문에 가장 상단으로 노출되지 않음

### 해결 방법
  - 그러면 페이징하지 않은 전제 배열에서 배열을 조작해야되나 고민하던중
    typoORM orderBy 에 조건을 주어 정렬할 수 있다는 것을 알게되어, 해당 조건을 이용해 간단하게 처리하였다
  - orderBy 첫번째 인자에는 
    `CASE WHEN [alias.property] = :[ALIAS_DELEMETER] THEN 0 ELSE 1 END` 조건을 통해 
    `setParameter('ALIAS_DELEMETER', value )`에 제시한 값과 일치한 경우와 아닌경우를 0, 1로 sorting 한후, 
    두번째 인자에 sorting한 리스트를 또 한번 오름차순(ASC)으로 할지 내림차순(DESC)으로 할지 지정해주면 된다
 
### 예시 코드
 ```ts
   (...생략...)
    users
        .orderBy(
          'CASE WHEN mapper.followingId = :followingId THEN 0 ELSE 1 END',
          ORDER_BY_VALUE.ASC,
        )
        .setParameter('followingId', userId);
   (...생략...)
 ```   