### PR TITLE
fix: 차단 유저에 따른 유저리스트 노출 버그 수정

### DIFF
--- a/src/modules/chat/chat.service.ts
+++ b/src/modules/chat/chat.service.ts
@@ -1,8 +1,90 @@
 import { Injectable } from '@nestjs/common';
+import { Socket } from 'socket.io';
+import { v4 as uuidv4 } from 'uuid';
+
+interface ChatRoomInfo {
+  roomId: string;
+  user1: string;
+  user2: string;
+}
 
 @Injectable()
 export class ChatService {
+  private chatRooms: Map<string, Set<Socket>> = new Map();
+  private chatRoomInfoList: ChatRoomInfo[] = [];
   getHello(): string {
     return 'Hello World!';
+  }
+
+  createRoom(roomId: string, client: Socket) {
+    if (!this.chatRooms.has(roomId)) {
+      this.chatRooms.set(roomId, new Set());
+    }
+    this.chatRooms.get(roomId).add(client);
+    client.join(roomId);
+  }
+  joinRoom(client: Socket, roomId: string) {
+    if (!this.chatRooms.has(roomId)) {
+      this.chatRooms.set(roomId, new Set());
+    }
+    this.chatRooms.get(roomId).add(client);
+    client.join(roomId);
+  }
+  getAllRoomIds(): ChatRoomInfo[] {
+    return this.chatRoomInfoList;
+  }
+
+  removeClientFromRooms(client: Socket) {
+    this.chatRooms.forEach((clients, roomId) => {
+      if (clients.has(client)) {
+        clients.delete(client);
+        client.leave(roomId);
+      }
+      if (clients.size === 0) {
+        this.chatRooms.delete(roomId);
+      }
+    });
+  }
+
+  createOrJoinChatRoom(user1: string, user2: string): string {
+    const existingRoomId = this.findChatRoom(user1, user2);
+    if (existingRoomId) {
+      console.log('이미 채팅방이 있습니다.');
+      return existingRoomId;
+    }
+    console.log('새 채팅방을 생성합니다.');
+    const roomId = uuidv4();
+    const chatRoomInfo: ChatRoomInfo = {
+      roomId,
+      user1,
+      user2,
+    };
+    this.chatRoomInfoList.push(chatRoomInfo);
+    this.chatRooms.set(roomId, new Set([user1, user2]));
+    return roomId;
+  }
+
+  private findChatRoom(user1: string, user2: string): string | undefined {
+    for (const [roomId, users] of this.chatRooms.entries()) {
+      if (users.has(user1) && users.has(user2)) {
+        return roomId;
+      }
+    }
+    return undefined;
+  }
+
+  findUserInRoom(roomId: string, user1: string): string | undefined {
+    const chatRoomInfo = this.chatRoomInfoList.find(
+      (info) =>
+        info.roomId === roomId &&
+        (info.user1 === user1 || info.user2 === user1),
+    );
+    if (chatRoomInfo) {
+      return user1 === chatRoomInfo.user1
+        ? chatRoomInfo.user2
+        : chatRoomInfo.user1;
+    }
+
+    return undefined;
   }
 }

--- a/src/modules/chat/dto/chat-user-gateway.dto.ts
+++ b/src/modules/chat/dto/chat-user-gateway.dto.ts
@@ -1,0 +1,5 @@
+export class ChatUserGatewayDto {
+  roomId: string;
+  userId: number;
+  message?: string;
+}

--- a/src/modules/chat/dto/index.ts
+++ b/src/modules/chat/dto/index.ts
@@ -1,0 +1,1 @@
+export * from './chat-user-gateway.dto';


### PR DESCRIPTION
## 🐳 개요
차단 유저에 따른 유저리스트 노출 버그 수정

## 🐳 작업사항
- 오류사항  
   -  차단 유저(나를 차단한 유저 )를 제외하는 로직과 orderBy에서 본인 id를 가장 상단에 노출 시키는 쿼리에 대한 적용이 제대로 안되는 부분
- 해결 
   - user 리스트중 차단 유저에다한 로직과 orderBy로 유저 순서를 정렬하는 로직이 제대로 적용될 수 있도록 let 으로 선언 변경한후 각 로직에 대한 코드 리팩토링 

