### PR TITLE
fix: 차단 유저 팔로잉/팔로워 목록 제외 버그 수정

### DIFF
--- a/src/modules/mapper-user-follow/mapper-user-follow.repository.ts
+++ b/src/modules/mapper-user-follow/mapper-user-follow.repository.ts
@@ -50,8 +50,8 @@ export class MapperUserFollowRepository {
       });
 
     if (excludeUserIds.length > 0) {
-      users.andWhere('mapper.followingId NOT IN (:...followingId)', {
-        followingId: [...excludeUserIds],
+      users.andWhere('mapper.followingId NOT IN (:...excludeUserIds)', {
+        excludeUserIds,
       });
     }
 
@@ -117,8 +117,8 @@ export class MapperUserFollowRepository {
       });
 
     if (excludeUserIds.length > 0) {
-      users.andWhere('mapper.userId NOT IN (:...userId)', {
-        userId: [...excludeUserIds],
+      users.andWhere('mapper.userId NOT IN (:...excludeUserIds)', {
+        excludeUserIds,
       });
     }
 


### PR DESCRIPTION
## 🐳 개요
차단 유저 팔로잉/팔로워 목록 제외 버그 수정

## 🐳 작업사항
팔로잉/팔로워 목록에서 나를 차단한 유저를 제외하고 보여주는 로직관련 버그 수정
변수가 잘못들어가있던 부분을 수정


